### PR TITLE
Rest of unit tests for payload tracker

### DIFF
--- a/test/watchers/payload_tracker_watcher_test.py
+++ b/test/watchers/payload_tracker_watcher_test.py
@@ -92,3 +92,8 @@ def test_payload_tracker_watcher_publish_status(producer_init_mock):
         b'{"service": "ccx-data-pipeline", "request_id": "some request id", '
         b'"status": "error", "date": "2020-05-07T14:00:00", "status_msg": "Something"}',
     )
+
+    # call _publish_status without request_id and check there is not any
+    # exception thrown
+    del mocked_values["request_id"]
+    sut.on_recv(mocked_input_message)

--- a/test/watchers/payload_tracker_watcher_test.py
+++ b/test/watchers/payload_tracker_watcher_test.py
@@ -71,3 +71,24 @@ def test_payload_tracker_watcher_publish_status(producer_init_mock):
         b'{"service": "ccx-data-pipeline", "request_id": "some request id", '
         b'"status": "received", "date": "2020-05-07T14:00:00"}',
     )
+
+    sut.on_process(mocked_input_message, "{result}")
+    producer_mock.send.assert_called_with(
+        "valid_topic",
+        b'{"service": "ccx-data-pipeline", "request_id": "some request id", '
+        b'"status": "processing", "date": "2020-05-07T14:00:00"}',
+    )
+
+    sut.on_consumer_success(mocked_input_message, "broker", "{result}")
+    producer_mock.send.assert_called_with(
+        "valid_topic",
+        b'{"service": "ccx-data-pipeline", "request_id": "some request id", '
+        b'"status": "success", "date": "2020-05-07T14:00:00"}',
+    )
+
+    sut.on_consumer_failure(mocked_input_message, Exception("Something"))
+    producer_mock.send.assert_called_with(
+        "valid_topic",
+        b'{"service": "ccx-data-pipeline", "request_id": "some request id", '
+        b'"status": "error", "date": "2020-05-07T14:00:00", "status_msg": "Something"}',
+    )


### PR DESCRIPTION
# Description

Rest of unit tests for payload tracker

## Type of change

- Unit tests (no changes in the code)

## Testing steps

Done on CI

## Checklist
* [ ] `make before_commit` passes
* [ ] updated documentation wherever necessary
* [ ] added or modified tests if necessary
* [ ] updated schemas and validators in [insights-data-schemas](https://github.com/RedHatInsights/insights-data-schemas) in case of input/output change
