### PR TITLE
Support minio URL in ephemeral environment

### DIFF
--- a/ccx_messaging/downloaders/http_downloader.py
+++ b/ccx_messaging/downloaders/http_downloader.py
@@ -70,7 +70,8 @@ class HTTPDownloader:
     HTTP_RE = re.compile(
         r"^(?:https://[^/]+\.s3\.amazonaws\.com/[0-9a-zA-Z/\-]+|"
         r"https://s3\.[0-9a-zA-Z\-]+\.amazonaws\.com/[0-9a-zA-Z\-]+/[0-9a-zA-Z/\-]+|"
-        r"http://minio:9000/insights-upload-perma/[0-9a-zA-Z\.\-]+/[0-9a-zA-Z\-]+)\?"
+        r"http://(env-ephemeral-[0-9a-zA-Z/\-]+-)?minio(\.ephemeral-[0-9a-zA-Z/\-]+\.svc)?:9000/"
+        r"insights-upload-perma/[0-9a-zA-Z\.\-]+/[0-9a-zA-Z\-]+)\?"
         r"X-Amz-Algorithm=AWS4-HMAC-SHA256&X-Amz-Credential=[^/]+$"
     )
 


### PR DESCRIPTION
# Description

Minio URL in ephemeral environment doesn't match HTTP_RE.

## Type of change

- Bug fix (non-breaking change which fixes an issue)

## Testing steps

Tested the regular expression if it matches the ephemeral environment URL and if it's backward compatible to the original expression on the changed line.

## Checklist
* [ ] `make before_commit` passes
* [ ] updated documentation wherever necessary
* [ ] added or modified tests if necessary
* [ ] updated schemas and validators in [insights-data-schemas](https://github.com/RedHatInsights/insights-data-schemas) in case of input/output change
