### PR TITLE
Add anemic consumer: consume topic and filter by service

### DIFF
--- a/ccx_messaging/error.py
+++ b/ccx_messaging/error.py
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-"""Module containing the implementation of the `SHAMessagingError` exception class."""
+"""Module containing the implementation of the `CCXMessagingError` exception class."""
 
 
 class CCXMessagingError(Exception):


### PR DESCRIPTION
# Description

New `AnemicConsumer` class for consuming the `platform.upload.announce` topic and filtering the messages based on the `service` header.

## Type of change

- New feature (non-breaking change which adds functionality)

## Testing steps

- Tested manually with ingress + sha-extractor, Added UTs, BDDs ongoing

## Checklist
* [x] `make before_commit` passes
* [] updated documentation wherever necessary
* [x] added or modified tests if necessary
* [ ] updated schemas and validators in [insights-data-schemas](https://github.com/RedHatInsights/insights-data-schemas) in case of input/output change
