### PR TITLE
Upgrade wheel and setup in travis CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -10,6 +10,8 @@ python:
 # needed to work correctly with Python 3 shebang
 env: SKIP_INTERPRETER=true
 install:
+  - pip install --upgrade setuptools
+  - pip install --upgrade wheel
   - pip install pycodestyle
   - pip install pydocstyle
   - pip install pytest-cov


### PR DESCRIPTION
# Description

Attempt to fix the CI issue seen in previous jobs with python 3.7.

```
$ pip install -r requirements.txt
226Collecting git+https://github.com/RedHatInsights/insights-core-messaging@1.2.2 (from -r requirements.txt (line 4))
227  Cloning https://github.com/RedHatInsights/insights-core-messaging (to revision 1.2.2) to /tmp/pip-req-build-vmsl43ex
228  Running command git clone --filter=blob:none --quiet https://github.com/RedHatInsights/insights-core-messaging /tmp/pip-req-build-vmsl43ex
229  Running command git checkout -q c6ec7f06333a34c0431acd145101157f77ee5355
230  Resolved https://github.com/RedHatInsights/insights-core-messaging to commit c6ec7f06333a34c0431acd145101157f77ee5355
231  Preparing metadata (setup.py) ... error
232  error: subprocess-exited-with-error
233  
234  × python setup.py egg_info did not run successfully.
235  │ exit code: 1
236  ╰─> [22 lines of output]
237      Traceback (most recent call last):
238        File "<string>", line 36, in <module>
239        File "<pip-setuptools-caller>", line 14, in <module>
240        File "/home/travis/virtualenv/python3.7.1/lib/python3.7/site-packages/setuptools/__init__.py", line 18, in <module>
241          from setuptools.dist import Distribution
242        File "/home/travis/virtualenv/python3.7.1/lib/python3.7/site-packages/setuptools/dist.py", line 34, in <module>
243          from ._importlib import metadata
244        File "/home/travis/virtualenv/python3.7.1/lib/python3.7/site-packages/setuptools/_importlib.py", line 28, in <module>
245          disable_importlib_metadata_finder(metadata)
246        File "/home/travis/virtualenv/python3.7.1/lib/python3.7/site-packages/setuptools/_importlib.py", line 12, in disable_importlib_metadata_finder
247          import importlib_metadata
248        File "/home/travis/virtualenv/python3.7.1/lib/python3.7/site-packages/importlib_metadata/__init__.py", line 471, in <module>
249          __version__ = version(__name__)
250        File "/home/travis/virtualenv/python3.7.1/lib/python3.7/site-packages/importlib_metadata/__init__.py", line 438, in version
251          return distribution(package).version
252        File "/home/travis/virtualenv/python3.7.1/lib/python3.7/site-packages/importlib_metadata/__init__.py", line 411, in distribution
253          return Distribution.from_name(package)
254        File "/home/travis/virtualenv/python3.7.1/lib/python3.7/site-packages/importlib_metadata/__init__.py", line 179, in from_name
255          dists = resolver(name)
256        File "/home/travis/virtualenv/python3.7.1/lib/python3.7/site-packages/setuptools/_vendor/importlib_metadata/__init__.py", line 886, in find_distributions
257          found = self._search_paths(context.name, context.path)
258      AttributeError: 'str' object has no attribute 'name'
259      [end of output]
```


Fixes CI

## Type of change

- Bug fix (non-breaking change which fixes an issue)


## Testing steps

Can't reproduce locally.

## Checklist
* [ ] `make before_commit` passes
* [ ] updated documentation wherever necessary
* [ ] added or modified tests if necessary
* [ ] updated schemas and validators in [insights-data-schemas](https://github.com/RedHatInsights/insights-data-schemas) in case of input/output change
