### PR TITLE
Get destination service from header

### DIFF
--- a/ccx_messaging/consumers/consumer.py
+++ b/ccx_messaging/consumers/consumer.py
@@ -116,25 +116,29 @@ class Consumer(ICMConsumer):
         self.dead_letter_queue_topic = dead_letter_queue_topic
         self.producer = KafkaProducer(bootstrap_servers=bootstrap_servers)
 
+    def _consume(self, msg):
+        try:
+            alarm(self.processing_timeout)
+            if self.handles(msg):
+                self.process(msg)
+            else:
+                self.process_dead_letter(msg)
+            alarm(0)
+        except TimeoutError as ex:
+            LOG.exception(ex)
+            self.process_dead_letter(msg)
+            self.fire("on_process_timeout")
+        except Exception as ex:
+            LOG.exception(ex)
+            self.process_dead_letter(msg)
+
     # pylint: disable=broad-except
     def run(self):
         """Execute the consumer logic."""
         signal(SIGALRM, handle_message_processing_timeout)
         for msg in self.consumer:
-            try:
-                alarm(self.processing_timeout)
-                if self.handles(msg):
-                    self.process(msg)
-                else:
-                    self.process_dead_letter(msg)
-                alarm(0)
-            except TimeoutError as ex:
-                LOG.exception(ex)
-                self.process_dead_letter(msg)
-                self.fire("on_process_timeout")
-            except Exception as ex:
-                LOG.exception(ex)
-                self.process_dead_letter(msg)
+            self._consume(msg)
+
 
     def process_dead_letter(self, msg):
         """Send unprocessed message to the dead letter queue topic."""
@@ -145,6 +149,40 @@ class Consumer(ICMConsumer):
         else:
             # just add at least some record in case that the message is not of the expected type
             self.producer.send(self.dead_letter_queue_topic, str(msg).encode("utf-8"))
+
+    def _validate(self, msg):
+        try:
+            jsonschema.validate(instance=msg, schema=INPUT_MESSAGE_SCHEMA)
+            LOG.debug("JSON schema validated (%s)", self.log_pattern)
+            b64_identity = msg["b64_identity"]
+
+            if isinstance(b64_identity, str):
+                b64_identity = b64_identity.encode()
+
+            decoded_identity = json.loads(base64.b64decode(b64_identity))
+            jsonschema.validate(instance=decoded_identity, schema=IDENTITY_SCHEMA)
+            LOG.debug("Identity schema validated (%s)", self.log_pattern)
+
+            msg["ClusterName"] = (
+                decoded_identity.get("identity", {})
+                    .get("system", {})
+                    .get("cluster_id", None)
+            )
+
+            msg["identity"] = decoded_identity
+            del msg["b64_identity"]
+            return msg
+
+        except json.JSONDecodeError as ex:
+            return CCXMessagingError(f"Unable to decode received message: {ex}")
+
+        except jsonschema.ValidationError as ex:
+            return CCXMessagingError(f"Invalid input message JSON schema: {ex}")
+
+        except binascii.Error as ex:
+            return CCXMessagingError(
+                f"Base64 encoded identity could not be parsed: {ex}"
+            )
 
     def deserialize(self, bytes_):
         """
@@ -161,39 +199,9 @@ class Consumer(ICMConsumer):
 
         if isinstance(bytes_, (str, bytes, bytearray)):
             try:
-                msg = json.loads(bytes_)
-                jsonschema.validate(instance=msg, schema=INPUT_MESSAGE_SCHEMA)
-                LOG.debug("JSON schema validated (%s)", self.log_pattern)
-                b64_identity = msg["b64_identity"]
-
-                if isinstance(b64_identity, str):
-                    b64_identity = b64_identity.encode()
-
-                decoded_identity = json.loads(base64.b64decode(b64_identity))
-                jsonschema.validate(instance=decoded_identity, schema=IDENTITY_SCHEMA)
-                LOG.debug("Identity schema validated (%s)", self.log_pattern)
-
-                msg["ClusterName"] = (
-                    decoded_identity.get("identity", {})
-                    .get("system", {})
-                    .get("cluster_id", None)
-                )
-
-                msg["identity"] = decoded_identity
-                del msg["b64_identity"]
-                return msg
-
+                return self._validate(json.loads(bytes_))
             except json.JSONDecodeError as ex:
                 return CCXMessagingError(f"Unable to decode received message: {ex}")
-
-            except jsonschema.ValidationError as ex:
-                return CCXMessagingError(f"Invalid input message JSON schema: {ex}")
-
-            except binascii.Error as ex:
-                return CCXMessagingError(
-                    f"Base64 encoded identity could not be parsed: {ex}"
-                )
-
         else:
             return CCXMessagingError(
                 f"Unexpected input message type: {bytes_.__class__.__name__}"
@@ -331,7 +339,10 @@ class AnemicConsumer(Consumer):
     internal engine for further processing.
     """
 
-    OTHER_SERVICE_DEBUG_MESSAGE = "Message is for another service. Ignoring"
+    EXPECTED_SERVICE_DEBUG_MESSAGE = "Received message for expected service."
+    OTHER_SERVICE_DEBUG_MESSAGE = "Message is for {} service. Ignoring"
+    NO_SERVICE_DEBUG_MESSAGE = "Message does not specify destination service. Ignoring"
+    NO_HEADER_DEBUG_MESSAGE = "Message does not contain headers. Ignoring"
 
     def __init__(
         self,
@@ -357,7 +368,7 @@ class AnemicConsumer(Consumer):
                          heartbeat_interval_ms, session_timeout_ms,
                          dead_letter_queue_topic, max_record_age, retry_backoff_ms,
                          processing_timeout_s, **kwargs)
-        self.platform_service = platform_service # we only handle buckit, but this could be a set of service names for future proofing
+        self.platform_service = platform_service.encode("utf-8")
 
     def deserialize(self, bytes_):
         """
@@ -374,20 +385,30 @@ class AnemicConsumer(Consumer):
 
         if isinstance(bytes_, (str, bytes, bytearray)):
             try:
-                msg = json.loads(bytes_)
-                if "service" not in msg or "service" in msg and msg["service"] != self.platform_service:
-                    LOG.debug(AnemicConsumer.OTHER_SERVICE_DEBUG_MESSAGE)
-                    return ""
-                LOG.debug(f"Received message for {self.platform_service} service.")
-                return super().deserialize(bytes_)
-
+                return json.loads(bytes_)
             except json.JSONDecodeError as ex:
                 return CCXMessagingError(f"Unable to decode received message: {ex}")
-
-            except jsonschema.ValidationError as ex:
-                return CCXMessagingError(f"Invalid input message JSON schema: {ex}")
         else:
             return CCXMessagingError(
                 f"Unexpected input message type: {bytes_.__class__.__name__}"
             )
 
+    def run(self):
+        """Execute the consumer logic."""
+        signal(SIGALRM, handle_message_processing_timeout)
+        for msg in self.consumer:
+            headers = dict(msg.headers)
+            if not headers:
+                LOG.debug(AnemicConsumer.NO_HEADER_DEBUG_MESSAGE)
+                continue
+            service = headers.get('service')
+            if service:
+                if service != self.platform_service:
+                    LOG.debug(AnemicConsumer.OTHER_SERVICE_DEBUG_MESSAGE.format(service))
+                    continue
+                LOG.debug(AnemicConsumer.EXPECTED_SERVICE_DEBUG_MESSAGE)
+                msg_value = self._validate(msg.value)
+                msg = msg._replace(value=msg_value)
+                self._consume(msg)
+            else:
+                LOG.debug(AnemicConsumer.NO_SERVICE_DEBUG_MESSAGE)

--- a/test/consumers/consumer_test.py
+++ b/test/consumers/consumer_test.py
@@ -23,6 +23,7 @@ from unittest.mock import patch
 import pytest
 
 from kafka import KafkaConsumer, KafkaProducer
+from kafka.consumer.fetcher import ConsumerRecord
 
 from ccx_messaging.consumers.consumer import Consumer
 from ccx_messaging.consumers.consumer import AnemicConsumer
@@ -393,35 +394,17 @@ _VALID_SERVICES = [
 ]
 
 _VALID_MESSAGES_WITH_UNEXPECTED_SERVICE_HEADER = [
-    (
-        '{"url": "",'
-        '"b64_identity": "eyJpZGVudGl0eSI6IHsiaW50ZXJuYWwiOiB7Im9yZ19pZCI6ICIxMjM0NTY3OCJ9fX0K",'
-        '"timestamp": "2020-01-23T16:15:59.478901889Z",'
-        '"service": "an_unexpected_service_name"}',
-        {
-            "url": "",
-            "identity": {"identity": {"internal": {"org_id": "12345678"}}},
-            "timestamp": "2020-01-23T16:15:59.478901889Z",
-            "ClusterName": None,
-        },
-    )
+ConsumerRecord(topic='platform.upload.announce', partition=0, offset=24, timestamp=1661327909633, timestamp_type=0, key=None, value={'account': '0369233', 'category': 'archive', 'service': 'test_service', 'timestamp': '2022-08-24T07:58:29.6326987Z'}, headers=[('service', b'some_unexpected_service')], checksum=1234, serialized_key_size=12, serialized_value_size=1, serialized_header_size=1)
 ]
 
 _VALID_MESSAGES_WITH_EXPECTED_SERVICE_HEADER = [
-    (
-        '{"url": "",'
-        '"b64_identity": "eyJpZGVudGl0eSI6IHsiaW50ZXJuYWwiOiB7Im9yZ19pZCI6ICIxMjM0NTY3OCJ9fX0K",'
-        '"timestamp": "2020-01-23T16:15:59.478901889Z",'
-        '"service": "test_service"}',
-        {
-            "url": "",
-            "identity": {"identity": {"internal": {"org_id": "12345678"}}},
-            "timestamp": "2020-01-23T16:15:59.478901889Z",
-            "ClusterName": None,
-            "service": "test_service",
-        },
-    )
+    ConsumerRecord(topic='platform.upload.announce', partition=0, offset=24, timestamp=1661327909633, timestamp_type=0, key=None, value={'account': '0369233', 'category': 'archive', 'service': 'test_service', 'timestamp': '2022-08-24T07:58:29.6326987Z'}, headers=[('service', b'test_service')], checksum=1234, serialized_key_size=12, serialized_value_size=1, serialized_header_size=1)
 ]
+
+_VALID_MESSAGES_WITH_NO_SERVICE_HEADER = [
+    ConsumerRecord(topic='platform.upload.announce', partition=0, offset=24, timestamp=1661327909633, timestamp_type=0, key=None, value={'account': '0369233', 'category': 'archive', 'service': 'test_service', 'timestamp': '2022-08-24T07:58:29.6326987Z'}, headers=[('some_header', 'some_value')], checksum=1234, serialized_key_size=12, serialized_value_size=1, serialized_header_size=1)
+]
+
 @pytest.mark.parametrize("topic", _VALID_TOPICS)
 @pytest.mark.parametrize("group", _VALID_GROUPS)
 @pytest.mark.parametrize("server", _VALID_SERVERS)
@@ -429,15 +412,13 @@ _VALID_MESSAGES_WITH_EXPECTED_SERVICE_HEADER = [
 def test_init_anemic_consumer(topic, group, server, service):
     """Test `AnemicConsumer` initialization."""
     sut = AnemicConsumer(None, None, None, group, topic, service, [server])
-    assert sut.platform_service == service
+    assert sut.platform_service == service.encode("utf-8")
     assert isinstance(sut.consumer, KafkaConsumer)
     assert sut.check_elapsed_time_thread.is_alive()
 
 
-@pytest.mark.parametrize("service", _VALID_SERVICES)
-def test_anemic_consumer_deserialize_no_service(service):
-    """Test run method of `AnemicConsumer` with no service in received message."""
-    platform_service = service
+def test_anemic_consumer_deserialize():
+    """Test deserialize method of `AnemicConsumer`"""
     consumer_message = _VALID_MESSAGES[0]
     buf = io.StringIO()
     log_handler = logging.StreamHandler(buf)
@@ -446,54 +427,79 @@ def test_anemic_consumer_deserialize_no_service(service):
     logger.addHandler(log_handler)
 
     with patch("ccx_messaging.consumers.consumer.LOG", logger):
-        sut = AnemicConsumer(None, None, None, platform_service=platform_service)
+        sut = AnemicConsumer(None, None, None, platform_service="any")
         deserialized = sut.deserialize(consumer_message[0])
-        assert isinstance(deserialized, str)
-        assert deserialized == ""
-        assert AnemicConsumer.OTHER_SERVICE_DEBUG_MESSAGE in buf.getvalue()
-
-    logger.removeHandler(log_handler)
-
-
-@pytest.mark.parametrize("service", _VALID_SERVICES)
-@pytest.mark.parametrize("msg", _VALID_MESSAGES_WITH_UNEXPECTED_SERVICE_HEADER)
-def test_anemic_consumer_deserialize_unexpected_service(service, msg):
-    """Test run method of `AnemicConsumer` with unexpected service in received message."""
-    platform_service = service
-    consumer_message = msg
-    buf = io.StringIO()
-    log_handler = logging.StreamHandler(buf)
-    logger = logging.getLogger()
-    logger.level = logging.DEBUG
-    logger.addHandler(log_handler)
-
-    with patch("ccx_messaging.consumers.consumer.LOG", logger):
-        sut = AnemicConsumer(None, None, None, platform_service=platform_service)
-        deserialized = sut.deserialize(consumer_message[0])
-        assert isinstance(deserialized, str)
-        assert deserialized == ""
-        assert AnemicConsumer.OTHER_SERVICE_DEBUG_MESSAGE in buf.getvalue()
-
-    logger.removeHandler(log_handler)
-
-
-@pytest.mark.parametrize("service", _VALID_SERVICES)
-@pytest.mark.parametrize("msg,value", _VALID_MESSAGES_WITH_EXPECTED_SERVICE_HEADER)
-def test_anemic_consumer_deserialize_expected_service(service, msg, value):
-    """Test deserialize method of `AnemicConsumer` with expected service in received message."""
-    platform_service = service
-    consumer_message = msg
-    buf = io.StringIO()
-    log_handler = logging.StreamHandler(buf)
-    logger = logging.getLogger()
-    logger.level = logging.DEBUG
-    logger.addHandler(log_handler)
-
-    with patch("ccx_messaging.consumers.consumer.LOG", logger):
-        sut = AnemicConsumer(None, None, None, platform_service=platform_service)
-        deserialized = sut.deserialize(consumer_message)
         assert isinstance(deserialized, dict)
-        assert deserialized == value
-        assert AnemicConsumer.OTHER_SERVICE_DEBUG_MESSAGE not in buf.getvalue()
+        assert deserialized.get('url') == ""
+        assert deserialized.get('b64_identity') == "eyJpZGVudGl0eSI6IHsiaW50ZXJuYWwiOiB7Im9yZ19pZCI6ICIxMjM0NTY3OCJ9fX0K"
+        assert deserialized.get('timestamp') == "2020-01-23T16:15:59.478901889Z"
 
+    logger.removeHandler(log_handler)
+
+
+@patch("ccx_messaging.consumers.consumer.Consumer.handles", lambda *a, **k: True)
+@patch("ccx_messaging.consumers.consumer.Consumer.fire", lambda *a, **k: None)
+@patch(
+    "ccx_messaging.consumers.consumer.Consumer.get_stringfied_record",
+    lambda *a, **k: None,
+)
+@pytest.mark.parametrize("service", _VALID_SERVICES)
+def test_anemic_consumer_run_no_service_in_header(service):
+    """Test run method of `AnemicConsumer` with no service in received message's header."""
+    buf = io.StringIO()
+    log_handler = logging.StreamHandler(buf)
+    logger = logging.getLogger()
+    logger.level = logging.DEBUG
+    logger.addHandler(log_handler)
+
+    with patch("ccx_messaging.consumers.consumer.LOG", logger):
+        sut = AnemicConsumer(None, None, None, platform_service=service)
+        sut.consumer = _VALID_MESSAGES_WITH_NO_SERVICE_HEADER
+        sut.run()
+        assert AnemicConsumer.NO_SERVICE_DEBUG_MESSAGE in buf.getvalue()
+
+    logger.removeHandler(log_handler)
+
+
+@pytest.mark.parametrize("service", _VALID_SERVICES)
+def test_anemic_consumer_run_unexpected_service(service):
+    """Test run method of `AnemicConsumer` with unexpected service in received message's header."""
+    buf = io.StringIO()
+    log_handler = logging.StreamHandler(buf)
+    logger = logging.getLogger()
+    logger.level = logging.DEBUG
+    logger.addHandler(log_handler)
+
+    with patch("ccx_messaging.consumers.consumer.LOG", logger):
+        sut = AnemicConsumer(None, None, None, platform_service=service)
+        sut.consumer = _VALID_MESSAGES_WITH_UNEXPECTED_SERVICE_HEADER
+        sut.run()
+        assert AnemicConsumer.OTHER_SERVICE_DEBUG_MESSAGE.format(b'some_unexpected_service') in buf.getvalue()
+
+    logger.removeHandler(log_handler)
+
+
+@patch("ccx_messaging.consumers.consumer.Consumer.handles", lambda *a, **k: True)
+@patch("ccx_messaging.consumers.consumer.Consumer.fire", lambda *a, **k: None)
+@patch(
+    "ccx_messaging.consumers.consumer.Consumer.get_stringfied_record",
+    lambda *a, **k: None,
+)
+@pytest.mark.parametrize("service", _VALID_SERVICES)
+def test_anemic_consumer_run_expected_service(service):
+    """Test run method of `AnemicConsumer` with expected service in received message's header."""
+    buf = io.StringIO()
+    log_handler = logging.StreamHandler(buf)
+    logger = logging.getLogger()
+    logger.level = logging.DEBUG
+    logger.addHandler(log_handler)
+
+    with patch("ccx_messaging.consumers.consumer.LOG", logger):
+        sut = AnemicConsumer(None, None, None, platform_service=service)
+        sut.consumer = _VALID_MESSAGES_WITH_EXPECTED_SERVICE_HEADER
+        sut.run()
+        logs = buf.getvalue()
+        assert AnemicConsumer.OTHER_SERVICE_DEBUG_MESSAGE not in logs
+        assert AnemicConsumer.NO_SERVICE_DEBUG_MESSAGE not in logs
+        assert AnemicConsumer.EXPECTED_SERVICE_DEBUG_MESSAGE in logs
     logger.removeHandler(log_handler)


### PR DESCRIPTION
# Description

- Retrieve the destination `service` from the consumed message's header instead of the message's value
  - `deserialize` is called before the headers are added to the Kafka `ConsumerRecord` object, so the logic has been moved to the `run` method of the `AnemicConsumer`.
- Some refactoring to avoid doing useless checks and modifications in the message's value when service is not the expected one:
  - move code to `_consume` and `_validate` to separate logic from `deserialise` and `run` methods.
  - validate (check identity header and add cluster data to message's body) after the destination service is verified in `run` method of the `AnemicConsumer`.

## Type of change

- New feature (non-breaking change which adds functionality)
- Refactor (refactoring code, removing useless files)

## Testing steps

- Added UTs
- Local testing with ingress + sha_extractor

## Checklist
* [x] `make before_commit` passes
* [ ] updated documentation wherever necessary
* [x] added or modified tests if necessary
* [ ] updated schemas and validators in [insights-data-schemas](https://github.com/RedHatInsights/insights-data-schemas) in case of input/output change
