### PR TITLE
Update versioning

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,3 @@
+[build-system]
+requires = ["setuptools", "wheel"]
+build-backend = "setuptools.build_meta"

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,10 +1,10 @@
 [metadata]
 name = ccx-messaging
 author = Red Hat Inc.
-description-file = README.md
+description_file = README.md
 license = Apache 2.0
 long_description_content_type = text/markdown
-home-page = https://github.com/RedHatInsights/insights-ccx-messaging
+home_page = https://github.com/RedHatInsights/insights-ccx-messaging
 classifier =
     Intended Audience :: Developers
     Natural Language :: English
@@ -24,6 +24,7 @@ install_requires =
     s3fs
     retry
 setup_requires =
+    build
     setuptools
     setuptools_scm
     wheel

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,7 +1,6 @@
 [metadata]
 name = ccx-messaging
 author = Red Hat Inc.
-version = 1.0.0
 description-file = README.md
 license = Apache 2.0
 long_description_content_type = text/markdown

--- a/setup.py
+++ b/setup.py
@@ -16,4 +16,4 @@
 
 from setuptools import setup
 
-setup()
+setup(use_scm_version={"local_scheme": "node-and-timestamp"})


### PR DESCRIPTION
# Description

Current versioning is always set to 1.0.0, while setuptools_scm is listed as dependency.
This change will provide a similar versioning as the one used in our other Python repositories

## Type of change

- Refactor (refactoring code, removing useless files)

## Testing steps

Locally run `python setup.py sdist` to check the generated version`

## Checklist
* [ ] `make before_commit` passes
* [ ] updated documentation wherever necessary
* [ ] added or modified tests if necessary
* [ ] updated schemas and validators in [insights-data-schemas](https://github.com/RedHatInsights/insights-data-schemas) in case of input/output change
