### PR TITLE
Adding topic parsing from clowder config

### DIFF
--- a/ccx_messaging/utils/clowder.py
+++ b/ccx_messaging/utils/clowder.py
@@ -13,11 +13,15 @@
 # limitations under the License.
 
 """Clowder integration functions."""
+import logging
 from tempfile import NamedTemporaryFile
 
 import yaml
-from app_common_python import LoadedConfig
+import app_common_python
 from app_common_python.types import BrokerConfigAuthtypeEnum
+
+
+logger = logging.getLogger(__name__)
 
 
 def apply_clowder_config(manifest):
@@ -25,8 +29,16 @@ def apply_clowder_config(manifest):
     Loader = getattr(yaml, "CSafeLoader", yaml.SafeLoader)
     config = yaml.load(manifest, Loader=Loader)
 
-    clowder_broker_config = LoadedConfig.kafka.brokers[0]
+    # Find the Payload Tracker watcher, as it might be affected by config changes
+    pt_watcher_name = "ccx_messaging.watchers.payload_tracker_watcher.PayloadTrackerWatcher"
+    watcher = None
+    for watcher in config["service"]["watchers"]:
+        if watcher["name"] == pt_watcher_name:
+            break
+
+    clowder_broker_config = app_common_python.LoadedConfig.kafka.brokers[0]
     kafka_url = f"{clowder_broker_config.hostname}:{clowder_broker_config.port}"
+    logger.debug("Kafka URL: %s", kafka_url)
 
     kafka_broker_config = {
         "bootstrap_servers": kafka_url,
@@ -34,9 +46,7 @@ def apply_clowder_config(manifest):
 
     if clowder_broker_config.cacert:
         # Current Kafka library is not able to handle the CA file, only a path to it
-        with NamedTemporaryFile("w", delete=False) as temp_file:
-            temp_file.write(clowder_broker_config.cacert)
-            kafka_broker_config["ssl_cafile"] = temp_file.name
+        kafka_broker_config["ssl_cafile"] = app_common_python.LoadedConfig.kafka_ca()
 
     if BrokerConfigAuthtypeEnum.valueAsString(clowder_broker_config.authtype) == "sasl":
         kafka_broker_config.update(
@@ -51,8 +61,42 @@ def apply_clowder_config(manifest):
     config["service"]["consumer"]["kwargs"].update(kafka_broker_config)
     config["service"]["publisher"]["kwargs"].update(kafka_broker_config)
 
-    pt_watcher = "ccx_messaging.watchers.payload_tracker_watcher.PayloadTrackerWatcher"
-    for watcher in config["service"]["watchers"]:
-        if watcher["name"] == pt_watcher:
-            watcher["kwargs"].update(kafka_broker_config)
+    if watcher:
+        watcher["kwargs"].update(kafka_broker_config)
+
+    logger.info("Kafka configuration updated from Clowder configuration")
+
+    consumer_topic = config["service"]["consumer"]["kwargs"].get("incoming_topic")
+    dlq_topic = config["service"]["consumer"]["kwargs"].get("dead_letter_queue_topic")
+    producer_topic = config["service"]["publisher"]["kwargs"].pop("outgoing_topic")
+    payload_tracker_topic = watcher["kwargs"].pop("topic")
+
+    if consumer_topic in app_common_python.KafkaTopics:
+        topic_cfg = app_common_python.KafkaTopics[consumer_topic]
+        config["service"]["consumer"]["kwargs"]["incoming_topic"] = topic_cfg.name
+    else:
+        logger.warn(
+            "The consumer topic cannot be found in Clowder mapping. It can cause errors"
+        )
+
+    if dlq_topic in app_common_python.KafkaTopics:
+        topic_cfg = app_common_python.KafkaTopics[dlq_topic]
+        config["service"]["consumer"]["kwargs"]["dead_letter_queue_topic"] = topic_cfg.name
+    
+    if producer_topic in app_common_python.KafkaTopics:
+        topic_cfg = app_common_python.KafkaTopics[producer_topic]
+        config["service"]["publisher"]["kwargs"]["outgoing_topic"] = topic_cfg.name
+    else:
+        logger.warn(
+            "The publisher topic cannot be found in Clowder mapping. It can cause errors"
+        )
+    
+    if payload_tracker_topic in app_common_python.KafkaTopics:
+        topic_cfg = app_common_python.KafkaTopics[payload_tracker_topic]
+        watcher["kwargs"]["topic"] = topic_cfg.name
+    else:
+        logger.warn(
+            "The Payload Tracker watcher topic cannot be found in Clowder mapping. It can cause errors"
+        )
+
     return config


### PR DESCRIPTION
# Description

The Kafka configuration provided by the Clowder configuration contains a "map" between requested topic names and their final names. The Kafka elements should use the final names instead of the requested ones, so the function mixing service configuration and Clowder provided one should take this into account and update the parameters accordingly.

Fixes #CCXDEV-9199 and #CCXDEV-9198

## Type of change

- New feature (non-breaking change which adds functionality)

## Testing steps

Tested locally

## Checklist
* [ ] `make before_commit` passes
* [ ] updated documentation wherever necessary
* [ ] added or modified tests if necessary
* [ ] updated schemas and validators in [insights-data-schemas](https://github.com/RedHatInsights/insights-data-schemas) in case of input/output change
