### PR TITLE
Adding org_id and account to Payload Tracker status updates

### DIFF
--- a/ccx_messaging/watchers/payload_tracker_watcher.py
+++ b/ccx_messaging/watchers/payload_tracker_watcher.py
@@ -47,6 +47,9 @@ class PayloadTrackerWatcher(ConsumerWatcher):
     def _publish_status(self, input_msg, status, status_msg=None):
         """Send an status update to payload tracker topic."""
         request_id = input_msg.value.get("request_id")
+        identity_field = input_msg.value.get("identity", {}).get("identity", {})
+        org_id = identity_field.get("internal", {}).get("org_id")
+        account = identity_field.get("account_number")
 
         if request_id is None:
             LOG.warning("The received record doesn't contain a request_id. It won't be reported")
@@ -58,6 +61,12 @@ class PayloadTrackerWatcher(ConsumerWatcher):
             "status": status,
             "date": datetime.datetime.now().isoformat(),
         }
+
+        if org_id:
+            tracker_msg["org_id"] = org_id
+
+        if account:
+            tracker_msg["account"] = account
 
         if status_msg:
             tracker_msg["status_msg"] = status_msg


### PR DESCRIPTION
# Description

The Payload Tracker is requiring a new field to be added in every status update (org_id) and allow to add the account number too.
The PR will include both for services that use the payload_tracker_watcher module from this library.

## Type of change

- New feature (non-breaking change which adds functionality)

## Testing steps

Local unit tests

## Checklist
* [x] `make before_commit` passes
* [ ] updated documentation wherever necessary
* [ ] added or modified tests if necessary
* [ ] updated schemas and validators in [insights-data-schemas](https://github.com/RedHatInsights/insights-data-schemas) in case of input/output change
