### PR TITLE
Fix producer configuration problem for Payload Tracker

### DIFF
--- a/ccx_messaging/watchers/payload_tracker_watcher.py
+++ b/ccx_messaging/watchers/payload_tracker_watcher.py
@@ -20,6 +20,7 @@ import logging
 
 from kafka import KafkaProducer
 
+from ccx_messaging.utils.kafka_config import producer_config
 from ccx_messaging.watchers.consumer_watcher import ConsumerWatcher
 
 LOG = logging.getLogger(__name__)
@@ -35,7 +36,9 @@ class PayloadTrackerWatcher(ConsumerWatcher):
         if not self.topic:
             raise KeyError("topic")
 
-        self.kafka_prod = KafkaProducer(bootstrap_servers=bootstrap_servers, **kwargs)
+        self.kafka_prod = KafkaProducer(
+            bootstrap_servers=bootstrap_servers, **producer_config(kwargs)
+        )
         self.service_name = service_name
 
         LOG.info(


### PR DESCRIPTION
# Description

Same problem with configuration for the Payload Tracker Watcher producer.

## Type of change

- Bug fix (non-breaking change which fixes an issue)

## Testing steps


## Checklist
* [x] `make before_commit` passes
* [ ] updated documentation wherever necessary
* [x] added or modified tests if necessary
* [ ] updated schemas and validators in [insights-data-schemas](https://github.com/RedHatInsights/insights-data-schemas) in case of input/output change
