### PR TITLE
Migrate DLQ producer from Kafka Python to Confluent

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,7 +1,7 @@
 exclude: "doc|research|demos"
 repos:
 - repo: https://github.com/psf/black
-  rev: 23.1.0
+  rev: 23.3.0
   hooks:
   - id: black
     args: [--safe, --quiet, --line-length, "100"]


### PR DESCRIPTION
# Description

In the effort to migrate from Kafka Python to Confluent Kafka library, the DLQ producer defined to send failed messages to a DLQ is updates.

Some unit tests were added to cover some uncovered cases.

Fixes #CCXDEV-10053

## Type of change

- Refactor (refactoring code, removing useless files)
- Unit tests (no changes in the code)

## Testing steps

Just checked using unit tests. To be tested in ephemeral

## Checklist
* [x] `make before_commit` passes
* [] updated documentation wherever necessary
* [x] added or modified tests if necessary
* [ ] updated schemas and validators in [insights-data-schemas](https://github.com/RedHatInsights/insights-data-schemas) in case of input/output change
