### PR TITLE
Add new Counter to stats regarding filtered messages

### DIFF
--- a/ccx_messaging/consumers/kafka_consumer.py
+++ b/ccx_messaging/consumers/kafka_consumer.py
@@ -158,6 +158,7 @@ class KafkaConsumer(Consumer):
 
         if not self.handles(msg):
             # already logged in self.handles
+            self.fire("on_filter")
             return
 
         try:

--- a/ccx_messaging/watchers/stats_watcher.py
+++ b/ccx_messaging/watchers/stats_watcher.py
@@ -36,6 +36,9 @@ class StatsWatcher(ConsumerWatcher):
         self._recv_total = Counter(
             "ccx_consumer_received_total", "Counter of received Kafka messages"
         )
+        self._filtered_total = Counter(
+            "ccx_consumer_filtered_total", "Counter of filtered Kafka messages"
+        )
 
         self._downloaded_total = Counter("ccx_downloaded_total", "Counter of downloaded items")
 
@@ -90,6 +93,10 @@ class StatsWatcher(ConsumerWatcher):
         self._start_time = time.time()
         self._reset_times()
 
+    def on_filter(self):
+        """On filter event handler."""
+        self._filtered_total.inc()
+
     def on_download(self, path):
         """On downloaded event handler."""
         self._downloaded_total.inc()
@@ -140,6 +147,7 @@ class StatsWatcher(ConsumerWatcher):
     def __del__(self):
         """Destructor for handling counters unregistering."""
         REGISTRY.unregister(self._recv_total)
+        REGISTRY.unregister(self._filtered_total)
         REGISTRY.unregister(self._downloaded_total)
         REGISTRY.unregister(self._processed_total)
         REGISTRY.unregister(self._published_total)

--- a/test/watchers/payload_tracker_watcher_test.py
+++ b/test/watchers/payload_tracker_watcher_test.py
@@ -59,8 +59,7 @@ def test_payload_tracker_init_with_kafka_config(producer_init_mock):
     """Check that passing a kafka_broker_config parameter updates the default ones."""
     kafka_broker_cfg = {"bootstrap.servers": "valid_server"}
 
-    producer_mock = _prepare_kafka_mock(producer_init_mock)
-    sut = PayloadTrackerWatcher(
+    PayloadTrackerWatcher(
         "valid_topic",
         kafka_broker_config=kafka_broker_cfg,
         **{"bootstrap.servers": "invalid_servicer"}

--- a/test/watchers/stats_watcher_test.py
+++ b/test/watchers/stats_watcher_test.py
@@ -47,6 +47,7 @@ def test_stats_watcher_initialize(start_http_server_mock, value):
 def check_initial_metrics_state(w):
     """Check that all metrics are initialized."""
     assert w._recv_total._value.get() == 0
+    assert w._filtered_total._value.get() == 0
     assert w._downloaded_total._value.get() == 0
     assert w._processed_total._value.get() == 0
     assert w._processed_timeout_total._value.get() == 0
@@ -64,6 +65,7 @@ def init_timestamps(w):
     w._published_time = t
 
 
+@patch("ccx_messaging.watchers.stats_watcher.start_http_server", lambda *args: None)
 def test_stats_watcher_on_recv():
     """Test the on_recv() method."""
     input_msg = {"identity": {}}
@@ -80,6 +82,7 @@ def test_stats_watcher_on_recv():
 
     # test new metrics values
     assert w._recv_total._value.get() == 1
+    assert w._filtered_total._value.get() == 0
     assert w._downloaded_total._value.get() == 0
     assert w._processed_total._value.get() == 0
     assert w._processed_timeout_total._value.get() == 0
@@ -88,6 +91,31 @@ def test_stats_watcher_on_recv():
     assert w._not_handling_total._value.get() == 0
 
 
+@patch("ccx_messaging.watchers.stats_watcher.start_http_server", lambda *args: None)
+def test_stats_watcher_on_filter():
+    """Test the on_filter() method."""
+    # construct watcher object
+    w = StatsWatcher(prometheus_port=8001)
+    init_timestamps(w)
+
+    # check that all metrics are initialized
+    check_initial_metrics_state(w)
+
+    # change metrics
+    w.on_filter()
+
+    # test new metrics values
+    assert w._recv_total._value.get() == 0
+    assert w._filtered_total._value.get() == 1
+    assert w._downloaded_total._value.get() == 0
+    assert w._processed_total._value.get() == 0
+    assert w._processed_timeout_total._value.get() == 0
+    assert w._published_total._value.get() == 0
+    assert w._failures_total._value.get() == 0
+    assert w._not_handling_total._value.get() == 0
+
+
+@patch("ccx_messaging.watchers.stats_watcher.start_http_server", lambda *args: None)
 def test_stats_watcher_on_download():
     """Test the on_download() method."""
     # construct watcher object
@@ -102,6 +130,7 @@ def test_stats_watcher_on_download():
 
     # test new metrics values
     assert w._recv_total._value.get() == 0
+    assert w._filtered_total._value.get() == 0
     assert w._downloaded_total._value.get() == 1
     assert w._processed_total._value.get() == 0
     assert w._processed_timeout_total._value.get() == 0
@@ -110,6 +139,7 @@ def test_stats_watcher_on_download():
     assert w._not_handling_total._value.get() == 0
 
 
+@patch("ccx_messaging.watchers.stats_watcher.start_http_server", lambda *args: None)
 def test_stats_watcher_on_process():
     """Test the on_process() method."""
     input_msg = {"identity": {}}
@@ -126,6 +156,7 @@ def test_stats_watcher_on_process():
 
     # test new metrics values
     assert w._recv_total._value.get() == 0
+    assert w._filtered_total._value.get() == 0
     assert w._downloaded_total._value.get() == 0
     assert w._processed_total._value.get() == 1
     assert w._processed_timeout_total._value.get() == 0
@@ -134,6 +165,7 @@ def test_stats_watcher_on_process():
     assert w._not_handling_total._value.get() == 0
 
 
+@patch("ccx_messaging.watchers.stats_watcher.start_http_server", lambda *args: None)
 def test_stats_watcher_on_process_timeout():
     """Test the on_process_timeout() method."""
     # construct watcher object
@@ -145,6 +177,7 @@ def test_stats_watcher_on_process_timeout():
 
     # test new metrics values
     assert w._recv_total._value.get() == 0
+    assert w._filtered_total._value.get() == 0
     assert w._downloaded_total._value.get() == 0
     assert w._processed_total._value.get() == 0
     assert w._processed_timeout_total._value.get() == 1
@@ -153,6 +186,7 @@ def test_stats_watcher_on_process_timeout():
     assert w._not_handling_total._value.get() == 0
 
 
+@patch("ccx_messaging.watchers.stats_watcher.start_http_server", lambda *args: None)
 def test_stats_watcher_on_consumer_success():
     """Test the on_consumer_success() method."""
     input_msg = {"identity": {}}
@@ -166,6 +200,7 @@ def test_stats_watcher_on_consumer_success():
 
     # test new metrics values
     assert w._recv_total._value.get() == 0
+    assert w._filtered_total._value.get() == 0
     assert w._downloaded_total._value.get() == 0
     assert w._processed_total._value.get() == 0
     assert w._processed_timeout_total._value.get() == 0
@@ -174,6 +209,7 @@ def test_stats_watcher_on_consumer_success():
     assert w._not_handling_total._value.get() == 0
 
 
+@patch("ccx_messaging.watchers.stats_watcher.start_http_server", lambda *args: None)
 def test_stats_watcher_on_consumer_failure():
     """Test the on_consumer_failure() method."""
     input_msg = {"identity": {}}
@@ -187,6 +223,7 @@ def test_stats_watcher_on_consumer_failure():
 
     # test new metrics values
     assert w._recv_total._value.get() == 0
+    assert w._filtered_total._value.get() == 0
     assert w._downloaded_total._value.get() == 0
     assert w._processed_total._value.get() == 0
     assert w._processed_timeout_total._value.get() == 0
@@ -223,6 +260,7 @@ def test_stats_watcher_on_consumer_failure():
     assert w._failures_total._value.get() == 4
 
 
+@patch("ccx_messaging.watchers.stats_watcher.start_http_server", lambda *args: None)
 def test_stats_watcher_on_not_handled():
     """Test the on_not_handled() method."""
     input_msg = {"identity": {}}
@@ -236,6 +274,7 @@ def test_stats_watcher_on_not_handled():
 
     # test new metrics values
     assert w._recv_total._value.get() == 0
+    assert w._filtered_total._value.get() == 0
     assert w._downloaded_total._value.get() == 0
     assert w._processed_total._value.get() == 0
     assert w._processed_timeout_total._value.get() == 0
@@ -244,6 +283,7 @@ def test_stats_watcher_on_not_handled():
     assert w._not_handling_total._value.get() == 1
 
 
+@patch("ccx_messaging.watchers.stats_watcher.start_http_server", lambda *args: None)
 def test_reset_times():
     """Test the method _reset_times()."""
     # construct watcher object


### PR DESCRIPTION
# Description

Adding a new counter to the existing metrics in order to count the number of messages received that are filtered out of the pipeline because the service id.

Fixes #CCXDEV-10008

## Type of change

- New feature (non-breaking change which adds functionality)
- Unit tests (no changes in the code)

## Testing steps

Run unit tests locally

## Checklist
* [x] `make before_commit` passes
* [ ] updated documentation wherever necessary
* [ ] added or modified tests if necessary
* [ ] updated schemas and validators in [insights-data-schemas](https://github.com/RedHatInsights/insights-data-schemas) in case of input/output change
