### PR TITLE
Removing default for a non-used parameter

### DIFF
--- a/ccx_messaging/consumers/kafka_consumer.py
+++ b/ccx_messaging/consumers/kafka_consumer.py
@@ -46,9 +46,6 @@ class KafkaConsumer(Consumer):
         if kafka_broker_config:
             kwargs.update(kafka_broker_config)
 
-        if "retry.backoff.ms" not in kwargs:
-            kwargs["retry.backoff.ms"] = 1000
-
         LOG.debug(
             "Confluent Kafka consumer configuration arguments: "
             "Group: %s. "

--- a/test/consumers/kafka_consumer_test.py
+++ b/test/consumers/kafka_consumer_test.py
@@ -246,7 +246,6 @@ def test_consumer_init_direct(topic, group, server):
             config = {
                 "bootstrap.servers": server,
                 "group.id": group,
-                "retry.backoff.ms": 1000,
             }
             mock_consumer_init.assert_called_with(config)
 


### PR DESCRIPTION
# Description

Currently the ccx-messaging based services using the Confluent Kafka Consumer are printing a warning message regarding the usage, in the configuration, of the parameter `retry.backoff.ms`. This parameter is only used by Kafka publishers, so it's nonsense to set it by default to consumers too

## Type of change

- Bug fix (non-breaking change which fixes an issue)

## Testing steps

Just run unit tests

## Checklist
* [x] `make before_commit` passes
* [ ] updated documentation wherever necessary
* [ ] added or modified tests if necessary
* [ ] updated schemas and validators in [insights-data-schemas](https://github.com/RedHatInsights/insights-data-schemas) in case of input/output change
