### PR TITLE
Adding clean up function for Kafka producer configurations

### DIFF
--- a/ccx_messaging/consumers/kafka_consumer.py
+++ b/ccx_messaging/consumers/kafka_consumer.py
@@ -9,6 +9,7 @@ from insights_messaging.consumers import Consumer
 
 from ccx_messaging.error import CCXMessagingError
 from ccx_messaging.ingress import parse_ingress_message
+from ccx_messaging.utils.kafka_config import kafka_producer_config_cleanup
 
 
 LOG = logging.getLogger(__name__)
@@ -85,7 +86,7 @@ class KafkaConsumer(Consumer):
         self.dead_letter_queue_topic = dead_letter_queue_topic
 
         if self.dead_letter_queue_topic is not None:
-            self.dlq_producer = Producer(kwargs)
+            self.dlq_producer = Producer(kafka_producer_config_cleanup(kwargs))
 
     def get_url(self, input_msg: dict) -> str:
         """

--- a/ccx_messaging/utils/kafka_config.py
+++ b/ccx_messaging/utils/kafka_config.py
@@ -32,3 +32,19 @@ def translate_kafka_configuration(config: dict) -> dict:
         lib_config[lib_key] = config[kafka_key]
 
     return lib_config
+
+
+def kafka_producer_config_cleanup(config):
+    """Clean up the configuration dictionary of consumer-only properties."""
+    consumer_only_properties = [
+        "group.id",
+        "session.timeout.ms",
+        "heartbeat.interval.ms",
+        "max.poll.interval.ms",
+    ]
+
+    for property in consumer_only_properties:
+        if property in config:
+            del config[property]
+
+    return config

--- a/ccx_messaging/watchers/payload_tracker_watcher.py
+++ b/ccx_messaging/watchers/payload_tracker_watcher.py
@@ -20,7 +20,9 @@ import logging
 
 from confluent_kafka import Producer
 
+from ccx_messaging.utils.kafka_config import kafka_producer_config_cleanup
 from ccx_messaging.watchers.consumer_watcher import ConsumerWatcher
+
 
 LOG = logging.getLogger(__name__)
 
@@ -37,6 +39,8 @@ class PayloadTrackerWatcher(ConsumerWatcher):
 
         if kafka_broker_config:
             kwargs.update(kafka_broker_config)
+        
+        kwargs = kafka_producer_config_cleanup(kwargs)
 
         LOG.debug(
             "Confluent Kafka consumer configuration arguments: "

--- a/test/utils/kafka_config_test.py
+++ b/test/utils/kafka_config_test.py
@@ -14,7 +14,7 @@
 
 """Test for the ccx_messaging.utils.kafka_config module."""
 
-from ccx_messaging.utils.kafka_config import translate_kafka_configuration
+from ccx_messaging.utils.kafka_config import translate_kafka_configuration, kafka_producer_config_cleanup
 
 
 def test_translate_kafka_configuration():
@@ -55,3 +55,21 @@ def test_translate_kafka_configuration_unexpected_keys_ignored():
     }
 
     assert translate_kafka_configuration(kafka_config) == expected_lib_config
+
+
+def test_kafka_producer_config_cleanup():
+    """Check the clean up function for producer' configurations."""
+    kafka_consumer_config = {
+        "group.id": "should delete",
+        "bootstrap.servers": "kafka:9092",
+        "session.timeout.ms": "1000",
+        "heartbeat.interval.ms": "1000",
+        "max.poll.interval.ms": "1000",
+    }
+
+    cfg = kafka_producer_config_cleanup(kafka_consumer_config)
+
+    assert "group.id" not in cfg
+    assert "session.timeout.ms" not in cfg
+    assert "heartbeat.interval.ms" not in cfg
+    assert "max.poll.interval.ms" not in cfg


### PR DESCRIPTION
# Description

Add an utility function to clean up the configuration parameters that can be pushed easily from clowder configuration injector that doesn't make sense in a producer

## Type of change

- Refactor (refactoring code, removing useless files)
- Unit tests (no changes in the code)

## Testing steps

Regular unit tests

## Checklist
* [ ] `make before_commit` passes
* [ ] updated documentation wherever necessary
* [ ] added or modified tests if necessary
* [ ] updated schemas and validators in [insights-data-schemas](https://github.com/RedHatInsights/insights-data-schemas) in case of input/output change
