### PR TITLE
Size metric

### DIFF
--- a/ccx_messaging/watchers/stats_watcher.py
+++ b/ccx_messaging/watchers/stats_watcher.py
@@ -15,6 +15,7 @@
 """Module including instrumentation to expose retrieved stats to Prometheus."""
 
 import logging
+import os
 import time
 
 from prometheus_client import Counter, Histogram, start_http_server, REGISTRY
@@ -40,7 +41,9 @@ class StatsWatcher(ConsumerWatcher):
             "ccx_consumer_filtered_total", "Counter of filtered Kafka messages"
         )
 
-        self._downloaded_total = Counter("ccx_downloaded_total", "Counter of downloaded items")
+        self._downloaded_total = Histogram(
+            "ccx_downloaded_total", "Histogram of the size of downloaded items"
+        )
 
         self._processed_total = Counter(
             "ccx_engine_processed_total", "Counter of files processed by the OCP Engine"
@@ -99,7 +102,7 @@ class StatsWatcher(ConsumerWatcher):
 
     def on_download(self, path):
         """On downloaded event handler."""
-        self._downloaded_total.inc()
+        self._downloaded_total.observe(os.path.getsize(path))
 
         self._downloaded_time = time.time()
         self._download_duration.observe(self._downloaded_time - self._start_time)

--- a/test/watchers/stats_watcher_test.py
+++ b/test/watchers/stats_watcher_test.py
@@ -48,7 +48,6 @@ def check_initial_metrics_state(w):
     """Check that all metrics are initialized."""
     assert w._recv_total._value.get() == 0
     assert w._filtered_total._value.get() == 0
-    assert w._downloaded_total._value.get() == 0
     assert w._processed_total._value.get() == 0
     assert w._processed_timeout_total._value.get() == 0
     assert w._published_total._value.get() == 0
@@ -83,7 +82,7 @@ def test_stats_watcher_on_recv():
     # test new metrics values
     assert w._recv_total._value.get() == 1
     assert w._filtered_total._value.get() == 0
-    assert w._downloaded_total._value.get() == 0
+    assert len(w._downloaded_total._labelvalues) == 0
     assert w._processed_total._value.get() == 0
     assert w._processed_timeout_total._value.get() == 0
     assert w._published_total._value.get() == 0
@@ -107,7 +106,7 @@ def test_stats_watcher_on_filter():
     # test new metrics values
     assert w._recv_total._value.get() == 0
     assert w._filtered_total._value.get() == 1
-    assert w._downloaded_total._value.get() == 0
+    assert w._downloaded_total._sum.get() == 0
     assert w._processed_total._value.get() == 0
     assert w._processed_timeout_total._value.get() == 0
     assert w._published_total._value.get() == 0
@@ -126,12 +125,13 @@ def test_stats_watcher_on_download():
     check_initial_metrics_state(w)
 
     # change metrics
-    w.on_download("path")
+    with patch("ccx_messaging.watchers.stats_watcher.os.path.getsize", lambda x: 100):
+        w.on_download("path")
 
     # test new metrics values
     assert w._recv_total._value.get() == 0
     assert w._filtered_total._value.get() == 0
-    assert w._downloaded_total._value.get() == 1
+    assert w._downloaded_total._sum.get() == 100
     assert w._processed_total._value.get() == 0
     assert w._processed_timeout_total._value.get() == 0
     assert w._published_total._value.get() == 0
@@ -157,7 +157,7 @@ def test_stats_watcher_on_process():
     # test new metrics values
     assert w._recv_total._value.get() == 0
     assert w._filtered_total._value.get() == 0
-    assert w._downloaded_total._value.get() == 0
+    assert w._downloaded_total._sum.get() == 0
     assert w._processed_total._value.get() == 1
     assert w._processed_timeout_total._value.get() == 0
     assert w._published_total._value.get() == 0
@@ -178,7 +178,7 @@ def test_stats_watcher_on_process_timeout():
     # test new metrics values
     assert w._recv_total._value.get() == 0
     assert w._filtered_total._value.get() == 0
-    assert w._downloaded_total._value.get() == 0
+    assert w._downloaded_total._sum.get() == 0
     assert w._processed_total._value.get() == 0
     assert w._processed_timeout_total._value.get() == 1
     assert w._published_total._value.get() == 0
@@ -201,7 +201,7 @@ def test_stats_watcher_on_consumer_success():
     # test new metrics values
     assert w._recv_total._value.get() == 0
     assert w._filtered_total._value.get() == 0
-    assert w._downloaded_total._value.get() == 0
+    assert w._downloaded_total._sum.get() == 0
     assert w._processed_total._value.get() == 0
     assert w._processed_timeout_total._value.get() == 0
     assert w._published_total._value.get() == 1
@@ -224,7 +224,7 @@ def test_stats_watcher_on_consumer_failure():
     # test new metrics values
     assert w._recv_total._value.get() == 0
     assert w._filtered_total._value.get() == 0
-    assert w._downloaded_total._value.get() == 0
+    assert w._downloaded_total._sum.get() == 0
     assert w._processed_total._value.get() == 0
     assert w._processed_timeout_total._value.get() == 0
     assert w._published_total._value.get() == 0
@@ -275,7 +275,7 @@ def test_stats_watcher_on_not_handled():
     # test new metrics values
     assert w._recv_total._value.get() == 0
     assert w._filtered_total._value.get() == 0
-    assert w._downloaded_total._value.get() == 0
+    assert w._downloaded_total._sum.get() == 0
     assert w._processed_total._value.get() == 0
     assert w._processed_timeout_total._value.get() == 0
     assert w._published_total._value.get() == 0


### PR DESCRIPTION
# Description

Modifying the existing "ccx_downloaded_total" metric to be an Histogram, so we can keep track of the size of the downloaded archives.

This change will break the Grafana boards for ccx-data-pipeline and ccx-sha-extractor. Take care when using the new version

Fixes #CCXDEV-10010

## Type of change

- Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Testing steps


## Checklist
* [x] `make before_commit` passes
* [ ] updated documentation wherever necessary
* [ ] added or modified tests if necessary
* [ ] updated schemas and validators in [insights-data-schemas](https://github.com/RedHatInsights/insights-data-schemas) in case of input/output change
