### PR TITLE
Change some log levels to adapt for log-size reduction

### DIFF
--- a/ccx_messaging/publishers/rule_processing_publisher.py
+++ b/ccx_messaging/publishers/rule_processing_publisher.py
@@ -61,7 +61,7 @@ class RuleProcessingPublisher(KafkaPublisher):
             account_number = int(input_msg["identity"]["identity"]["account_number"])
         except (ValueError, KeyError, TypeError) as err:
             log.warning(f"Error extracting the Account number: {err}")
-            account_number = ''
+            account_number = ""
 
         try:
             msg_timestamp = input_msg["timestamp"]
@@ -91,7 +91,7 @@ class RuleProcessingPublisher(KafkaPublisher):
                 output_msg["Version"],
             )
 
-            log.info(
+            log.debug(
                 "Status: Success; "
                 "Topic: %s; "
                 "Partition: %s; "

--- a/ccx_messaging/publishers/workloads_info_publisher.py
+++ b/ccx_messaging/publishers/workloads_info_publisher.py
@@ -63,7 +63,7 @@ class WorkloadInfoPublisher(KafkaPublisher):
             account_number = int(input_msg["identity"]["identity"]["account_number"])
         except (ValueError, KeyError, TypeError) as err:
             log.warning(f"Error extracting the Account number: {err}")
-            account_number = ''
+            account_number = ""
 
         # outgoing message in form of JSON
         message = ""
@@ -103,7 +103,7 @@ class WorkloadInfoPublisher(KafkaPublisher):
                 output_msg["Version"],
             )
 
-            log.info(
+            log.debug(
                 "Status: Success; "
                 "Topic: %s; "
                 "Partition: %s; "

--- a/ccx_messaging/watchers/payload_tracker_watcher.py
+++ b/ccx_messaging/watchers/payload_tracker_watcher.py
@@ -42,7 +42,7 @@ class PayloadTrackerWatcher(ConsumerWatcher):
 
         kwargs = kafka_producer_config_cleanup(kwargs)
 
-        LOG.debug(
+        LOG.info(
             "Confluent Kafka consumer configuration arguments: "
             "Server: %s. "
             "Topic: %s. "
@@ -66,6 +66,7 @@ class PayloadTrackerWatcher(ConsumerWatcher):
         identity_field = input_msg.get("identity", {}).get("identity", {})
         org_id = identity_field.get("internal", {}).get("org_id")
         account = identity_field.get("account_number")
+        cluster_name = input_msg.get("cluster_name", "")
 
         if request_id is None:
             LOG.warning("The received record doesn't contain a request_id. It won't be reported")
@@ -88,7 +89,12 @@ class PayloadTrackerWatcher(ConsumerWatcher):
             tracker_msg["status_msg"] = status_msg
 
         self.kafka_prod.produce(self.topic, json.dumps(tracker_msg).encode("utf-8"))
-        LOG.info("Payload Tracker update successfully sent: %s %s", request_id, status)
+        LOG.info(
+            "Payload Tracker update successfully sent for cluster %s: %s %s",
+            cluster_name,
+            request_id,
+            status,
+        )
 
     def on_recv(self, input_msg):
         """On received event handler."""

--- a/test/publishers/rule_processing_publisher_test.py
+++ b/test/publishers/rule_processing_publisher_test.py
@@ -125,92 +125,109 @@ def test_publish_bad_argument(wrong_input_msg):
 
 
 VALID_INPUT_MSG = [
-    pytest.param({
-        "identity": {
+    pytest.param(
+        {
             "identity": {
-                "internal": {"org_id": 10},
-                "account_number": 1,
+                "identity": {
+                    "internal": {"org_id": 10},
+                    "account_number": 1,
+                },
             },
+            "timestamp": "a timestamp",
+            "cluster_name": "uuid",
+            "request_id": "a request id",
+            "topic": "incoming_topic",
+            "partition": 0,
+            "offset": 100,
         },
-        "timestamp": "a timestamp",
-        "cluster_name": "uuid",
-        "request_id": "a request id",
-        "topic": "incoming_topic",
-        "partition": 0,
-        "offset": 100,
-    }, {
-        "OrgID": 10,
-        "AccountNumber": 1,
-        "ClusterName": "uuid",
-        "Report": {},
-        "LastChecked": "a timestamp",
-        "Version": 2,
-        "RequestId": "a request id",
-    }, id="with account"),
-    pytest.param({
-        "identity": {
+        {
+            "OrgID": 10,
+            "AccountNumber": 1,
+            "ClusterName": "uuid",
+            "Report": {},
+            "LastChecked": "a timestamp",
+            "Version": 2,
+            "RequestId": "a request id",
+        },
+        id="with account",
+    ),
+    pytest.param(
+        {
             "identity": {
-                "internal": {"org_id": 10},
-                "account_number": 5 + 2j,
+                "identity": {
+                    "internal": {"org_id": 10},
+                    "account_number": 5 + 2j,
+                },
             },
+            "timestamp": "a timestamp",
+            "cluster_name": "uuid",
+            "request_id": "a request id",
+            "topic": "incoming_topic",
+            "partition": 0,
+            "offset": 100,
         },
-        "timestamp": "a timestamp",
-        "cluster_name": "uuid",
-        "request_id": "a request id",
-        "topic": "incoming_topic",
-        "partition": 0,
-        "offset": 100,
-    }, {"OrgID": 10,
-        "AccountNumber": '',
-        "ClusterName": "uuid",
-        "Report": {},
-        "LastChecked": "a timestamp",
-        "Version": 2,
-        "RequestId": "a request id",
-        }, id="invalid account"),
-    pytest.param({
-        "identity": {
+        {
+            "OrgID": 10,
+            "AccountNumber": "",
+            "ClusterName": "uuid",
+            "Report": {},
+            "LastChecked": "a timestamp",
+            "Version": 2,
+            "RequestId": "a request id",
+        },
+        id="invalid account",
+    ),
+    pytest.param(
+        {
             "identity": {
-                "internal": {"org_id": 10},
-                "account_number": '',
+                "identity": {
+                    "internal": {"org_id": 10},
+                    "account_number": "",
+                },
             },
+            "timestamp": "a timestamp",
+            "cluster_name": "uuid",
+            "request_id": "a request id",
+            "topic": "incoming_topic",
+            "partition": 0,
+            "offset": 100,
         },
-        "timestamp": "a timestamp",
-        "cluster_name": "uuid",
-        "request_id": "a request id",
-        "topic": "incoming_topic",
-        "partition": 0,
-        "offset": 100,
-    }, {
-        "OrgID": 10,
-        "AccountNumber": '',
-        "ClusterName": "uuid",
-        "Report": {},
-        "LastChecked": "a timestamp",
-        "Version": 2,
-        "RequestId": "a request id",
-    }, id="empty account"),
-    pytest.param({
-        "identity": {
+        {
+            "OrgID": 10,
+            "AccountNumber": "",
+            "ClusterName": "uuid",
+            "Report": {},
+            "LastChecked": "a timestamp",
+            "Version": 2,
+            "RequestId": "a request id",
+        },
+        id="empty account",
+    ),
+    pytest.param(
+        {
             "identity": {
-                "internal": {"org_id": 10},
+                "identity": {
+                    "internal": {"org_id": 10},
+                },
             },
+            "timestamp": "a timestamp",
+            "cluster_name": "uuid",
+            "request_id": "a request id",
+            "topic": "incoming_topic",
+            "partition": 0,
+            "offset": 100,
         },
-        "timestamp": "a timestamp",
-        "cluster_name": "uuid",
-        "request_id": "a request id",
-        "topic": "incoming_topic",
-        "partition": 0,
-        "offset": 100,
-    }, {
-        "OrgID": 10,
-        "AccountNumber": '',
-        "ClusterName": "uuid",
-        "Report": {},
-        "LastChecked": "a timestamp",
-        "Version": 2,
-        "RequestId": "a request id",
-    }, id="no account"),
+        {
+            "OrgID": 10,
+            "AccountNumber": "",
+            "ClusterName": "uuid",
+            "Report": {},
+            "LastChecked": "a timestamp",
+            "Version": 2,
+            "RequestId": "a request id",
+        },
+        id="no account",
+    ),
 ]
 
 
@@ -219,12 +236,7 @@ def test_publish_valid(input, expected_output):
     """Check that Kafka producer is called with an expected message."""
     report = "{}"
 
-    expected_output = (
-        json.dumps(
-            expected_output
-        )
-        + "\n"
-    )
+    expected_output = json.dumps(expected_output) + "\n"
     sut = RuleProcessingPublisher("outgoing_topic", {"bootstrap.servers": "kafka:9092"})
     sut.producer = MagicMock()
 

--- a/test/publishers/workload_info_publisher_test.py
+++ b/test/publishers/workload_info_publisher_test.py
@@ -125,93 +125,109 @@ def test_publish_bad_argument(wrong_input_msg):
 
 
 VALID_INPUT_MSG = [
-    pytest.param({
-        "identity": {
+    pytest.param(
+        {
             "identity": {
-                "internal": {"org_id": 10},
-                "account_number": 1,
+                "identity": {
+                    "internal": {"org_id": 10},
+                    "account_number": 1,
+                },
             },
+            "timestamp": "a timestamp",
+            "cluster_name": "uuid",
+            "request_id": "a request id",
+            "topic": "incoming_topic",
+            "partition": 0,
+            "offset": 100,
         },
-        "timestamp": "a timestamp",
-        "cluster_name": "uuid",
-        "request_id": "a request id",
-        "topic": "incoming_topic",
-        "partition": 0,
-        "offset": 100,
-    }, {
-        "OrgID": 10,
-        "AccountNumber": 1,
-        "ClusterName": "uuid",
-        "Images": {},
-        "LastChecked": "a timestamp",
-        "Version": 2,
-        "RequestId": "a request id",
-    }, id="with account"),
-    pytest.param({
-        "identity": {
+        {
+            "OrgID": 10,
+            "AccountNumber": 1,
+            "ClusterName": "uuid",
+            "Images": {},
+            "LastChecked": "a timestamp",
+            "Version": 2,
+            "RequestId": "a request id",
+        },
+        id="with account",
+    ),
+    pytest.param(
+        {
             "identity": {
-                "internal": {"org_id": 10},
-                "account_number": 5 + 2j,
+                "identity": {
+                    "internal": {"org_id": 10},
+                    "account_number": 5 + 2j,
+                },
             },
+            "timestamp": "a timestamp",
+            "cluster_name": "uuid",
+            "request_id": "a request id",
+            "topic": "incoming_topic",
+            "partition": 0,
+            "offset": 100,
         },
-        "timestamp": "a timestamp",
-        "cluster_name": "uuid",
-        "request_id": "a request id",
-        "topic": "incoming_topic",
-        "partition": 0,
-        "offset": 100,
-    }, {
-        "OrgID": 10,
-        "AccountNumber": '',
-        "ClusterName": "uuid",
-        "Images": {},
-        "LastChecked": "a timestamp",
-        "Version": 2,
-        "RequestId": "a request id",
-    }, id="invalid account"),
-    pytest.param({
-        "identity": {
+        {
+            "OrgID": 10,
+            "AccountNumber": "",
+            "ClusterName": "uuid",
+            "Images": {},
+            "LastChecked": "a timestamp",
+            "Version": 2,
+            "RequestId": "a request id",
+        },
+        id="invalid account",
+    ),
+    pytest.param(
+        {
             "identity": {
-                "internal": {"org_id": 10},
-                "account_number": '',
+                "identity": {
+                    "internal": {"org_id": 10},
+                    "account_number": "",
+                },
             },
+            "timestamp": "a timestamp",
+            "cluster_name": "uuid",
+            "request_id": "a request id",
+            "topic": "incoming_topic",
+            "partition": 0,
+            "offset": 100,
         },
-        "timestamp": "a timestamp",
-        "cluster_name": "uuid",
-        "request_id": "a request id",
-        "topic": "incoming_topic",
-        "partition": 0,
-        "offset": 100,
-    }, {
-        "OrgID": 10,
-        "AccountNumber": '',
-        "ClusterName": "uuid",
-        "Images": {},
-        "LastChecked": "a timestamp",
-        "Version": 2,
-        "RequestId": "a request id",
-    }, id="empty account"),
-    pytest.param({
-        "identity": {
+        {
+            "OrgID": 10,
+            "AccountNumber": "",
+            "ClusterName": "uuid",
+            "Images": {},
+            "LastChecked": "a timestamp",
+            "Version": 2,
+            "RequestId": "a request id",
+        },
+        id="empty account",
+    ),
+    pytest.param(
+        {
             "identity": {
-                "internal": {"org_id": 10},
+                "identity": {
+                    "internal": {"org_id": 10},
+                },
             },
+            "timestamp": "a timestamp",
+            "cluster_name": "uuid",
+            "request_id": "a request id",
+            "topic": "incoming_topic",
+            "partition": 0,
+            "offset": 100,
         },
-        "timestamp": "a timestamp",
-        "cluster_name": "uuid",
-        "request_id": "a request id",
-        "topic": "incoming_topic",
-        "partition": 0,
-        "offset": 100,
-    }, {
-        "OrgID": 10,
-        "AccountNumber": '',
-        "ClusterName": "uuid",
-        "Images": {},
-        "LastChecked": "a timestamp",
-        "Version": 2,
-        "RequestId": "a request id",
-    }, id="no account"),
+        {
+            "OrgID": 10,
+            "AccountNumber": "",
+            "ClusterName": "uuid",
+            "Images": {},
+            "LastChecked": "a timestamp",
+            "Version": 2,
+            "RequestId": "a request id",
+        },
+        id="no account",
+    ),
 ]
 
 
@@ -220,12 +236,7 @@ def test_publish_valid(input, expected_output):
     """Check that Kafka producer is called with an expected message."""
     report = "{}"
 
-    expected_output = (
-        json.dumps(
-            expected_output
-        )
-        + "\n"
-    )
+    expected_output = json.dumps(expected_output) + "\n"
     sut = WorkloadInfoPublisher("outgoing_topic", {"bootstrap.servers": "kafka:9092"})
     sut.producer = MagicMock()
 


### PR DESCRIPTION
# Description

In order to reduce the amount of logs sent to CloudWatch, some log messages were decreased to "debug" and others increased to "info".

## Type of change

- Refactor (refactoring code, removing useless files)

## Testing steps

N/A

## Checklist
* [x] `make before_commit` passes
* [ ] updated documentation wherever necessary
* [ ] added or modified tests if necessary
* [ ] updated schemas and validators in [insights-data-schemas](https://github.com/RedHatInsights/insights-data-schemas) in case of input/output change
