### PR TITLE
Add gathering timestamp

### DIFF
--- a/ccx_messaging/publishers/rule_processing_publisher.py
+++ b/ccx_messaging/publishers/rule_processing_publisher.py
@@ -75,6 +75,14 @@ class RuleProcessingPublisher(KafkaPublisher):
                 "RequestId": input_msg.get("request_id"),
             }
 
+            gathered_at = input_msg.get("metadata", {}) \
+                                   .get("custom_metadata", {}) \
+                                   .get("gathering_time", None)
+            if gathered_at:
+                output_msg["Metadata"] = {
+                    "gathering_time": gathered_at
+                }
+
             message = json.dumps(output_msg) + "\n"
 
             log.debug("Sending response to the %s topic.", self.topic)

--- a/test/publishers/rule_processing_publisher_test.py
+++ b/test/publishers/rule_processing_publisher_test.py
@@ -261,7 +261,63 @@ VALID_INPUT_MSG = [
         },
         id="with gathering timestamp",
     ),
-
+    pytest.param(
+        {
+            "identity": {
+                "identity": {
+                    "internal": {"org_id": 10},
+                },
+            },
+            "timestamp": "a timestamp",
+            "cluster_name": "uuid",
+            "request_id": "a request id",
+            "topic": "incoming_topic",
+            "partition": 0,
+            "offset": 100,
+            "metadata": {
+                "custom_metadata": {
+                    "some_timestamp": "2023-08-14T09:31:46.677052"
+                }
+            }
+        },
+        {
+            "OrgID": 10,
+            "AccountNumber": "",
+            "ClusterName": "uuid",
+            "Report": {},
+            "LastChecked": "a timestamp",
+            "Version": 2,
+            "RequestId": "a request id"
+        },
+        id="with custom metadata without gathering timestamp",
+    ),
+    pytest.param(
+        {
+            "identity": {
+                "identity": {
+                    "internal": {"org_id": 10},
+                },
+            },
+            "timestamp": "a timestamp",
+            "cluster_name": "uuid",
+            "request_id": "a request id",
+            "topic": "incoming_topic",
+            "partition": 0,
+            "offset": 100,
+            "metadata": {
+            }
+        },
+        {
+            "OrgID": 10,
+            "AccountNumber": "",
+            "ClusterName": "uuid",
+            "Report": {},
+            "LastChecked": "a timestamp",
+            "Version": 2,
+            "RequestId": "a request id"
+        },
+        id="empty metadata",
+    ),
 ]
 
 

--- a/test/publishers/rule_processing_publisher_test.py
+++ b/test/publishers/rule_processing_publisher_test.py
@@ -228,6 +228,40 @@ VALID_INPUT_MSG = [
         },
         id="no account",
     ),
+    pytest.param(
+        {
+            "identity": {
+                "identity": {
+                    "internal": {"org_id": 10},
+                },
+            },
+            "timestamp": "a timestamp",
+            "cluster_name": "uuid",
+            "request_id": "a request id",
+            "topic": "incoming_topic",
+            "partition": 0,
+            "offset": 100,
+            "metadata": {
+                "custom_metadata": {
+                    "gathering_time": "2023-08-14T09:31:46.677052"
+                }
+            }
+        },
+        {
+            "OrgID": 10,
+            "AccountNumber": "",
+            "ClusterName": "uuid",
+            "Report": {},
+            "LastChecked": "a timestamp",
+            "Version": 2,
+            "RequestId": "a request id",
+            "Metadata": {
+                "gathering_time": "2023-08-14T09:31:46.677052"
+            }
+        },
+        id="with gathering timestamp",
+    ),
+
 ]
 
 


### PR DESCRIPTION
# Description

Includes gathering timestamp in messages produced by RuleProcessingPublisher. Without this change, the insights-results-aggregator does not have a data for filling `received_timestamp` field.

## Type of change

- Bug fix (non-breaking change which fixes an issue)

## Testing steps

- Input with gathering timestamp was reproduced in ephemeral environment (even though `iqe-ingress-plugin` had to be modified in order to achieve that)
- Output of `ccx-data-pipeline` has been checked in locally created environment.


## Checklist
* [ ] `make before_commit` passes
* [ ] updated documentation wherever necessary
* [x] added or modified tests if necessary
* [ ] updated schemas and validators in [insights-data-schemas](https://github.com/RedHatInsights/insights-data-schemas) in case of input/output change
