### PR TITLE
[CCXDEV-11876] Update confluent-kafka dependency to v2

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -19,7 +19,7 @@ packages = find:
 install_requires =
     app-common-python>=0.2.3
     boto3
-    confluent-kafka>=1.5.0,<2.0.0
+    confluent-kafka>=2.0.0
     insights-core>=3.1.2
     insights-core-messaging>=1.2.1
     jsonschema>=4.0.0


### PR DESCRIPTION
# Description

Update confluent-kafka to v2.2. This version supports Python 3.11

## Type of change

- Bump-up dependent library (no changes in the code)
