### PR TITLE
[CCXDEV-11583] Add report filtering

### DIFF
--- a/ccx_messaging/publishers/dvo_metrics_publisher.py
+++ b/ccx_messaging/publishers/dvo_metrics_publisher.py
@@ -38,6 +38,14 @@ class DVOMetricsPublisher(KafkaPublisher):
         to the producer to produce a message in the output Kafka topic.
         """
         output_msg = {}
+
+        try:
+            report = json.loads(report)
+        except (TypeError, json.decoder.JSONDecodeError):
+            raise CCXMessagingError("Could not parse report; report is not in JSON format")
+
+        report.pop("reports", None)
+
         try:
             org_id = int(input_msg["identity"]["identity"]["internal"]["org_id"])
         except (ValueError, KeyError, TypeError) as err:
@@ -56,7 +64,7 @@ class DVOMetricsPublisher(KafkaPublisher):
             "OrgID": org_id,
             "AccountNumber": account_number,
             "ClusterName": input_msg["cluster_name"],
-            "Metrics": json.loads(report),
+            "Metrics": report,
             "RequestId": input_msg.get("request_id"),
         }
         message = json.dumps(output_msg) + "\n"

--- a/ccx_messaging/publishers/rule_processing_publisher.py
+++ b/ccx_messaging/publishers/rule_processing_publisher.py
@@ -149,4 +149,4 @@ class RuleProcessingPublisher(KafkaPublisher):
 
         except (TypeError, UnicodeEncodeError, JSONDecodeError) as err:
             log.info(err)
-            raise CCXMessagingError(f"Error encoding the response to publish: {response}") from err
+            raise CCXMessagingError(f"Error encoding the response to publish: {report}") from err

--- a/ccx_messaging/publishers/rule_processing_publisher.py
+++ b/ccx_messaging/publishers/rule_processing_publisher.py
@@ -74,15 +74,21 @@ class RuleProcessingPublisher(KafkaPublisher):
 
         return gathered_at
 
-    def publish(self, input_msg, response):
+    def publish(self, input_msg, report):
         """Publish an EOL-terminated JSON message to the output Kafka topic.
 
-        The response is assumed to be a string representing a valid JSON object.
+        The report is assumed to be a string representing a valid JSON object.
         A newline character will be appended to it, it will be converted into
         a byte array using UTF-8 encoding and the result of that will be sent
         to the producer to produce a message in the output Kafka topic.
         """
-        # Response is already a string, no need to JSON dump.
+        try:
+            report = json.loads(report)
+        except (TypeError, json.decoder.JSONDecodeError):
+            raise CCXMessagingError("Could not parse report; report is not in JSON format")
+
+        report.pop("workload_recommendations", None)
+
         output_msg = {}
         try:
             org_id = int(input_msg["identity"]["identity"]["internal"]["org_id"])
@@ -101,7 +107,7 @@ class RuleProcessingPublisher(KafkaPublisher):
                 "OrgID": org_id,
                 "AccountNumber": account_number,
                 "ClusterName": input_msg["cluster_name"],
-                "Report": json.loads(response),
+                "Report": report,
                 "LastChecked": msg_timestamp,
                 "Version": self.outdata_schema_version,
                 "RequestId": input_msg.get("request_id"),

--- a/test/publishers/dvo_metrics_publisher_test.py
+++ b/test/publishers/dvo_metrics_publisher_test.py
@@ -410,6 +410,7 @@ VALID_REPORTS = [
 
 @pytest.mark.parametrize("input,expected_output", VALID_REPORTS)
 def test_filter_dvo_results(input, expected_output):
+    """Check that the external rule reports are filtered out from the engine results."""
     sut = DVOMetricsPublisher("outgoing_topic", {"bootstrap.servers": "kafka:9092"})
     sut.producer = MagicMock()
     expected_output = json.dumps(expected_output) + "\n"

--- a/test/publishers/rule_processing_publisher_test.py
+++ b/test/publishers/rule_processing_publisher_test.py
@@ -456,6 +456,7 @@ VALID_REPORTS = [
 @freezegun.freeze_time("2012-01-14")
 @pytest.mark.parametrize("input,expected_output", VALID_REPORTS)
 def test_filter_ocp_rules_results(input, expected_output):
+    """Check that the workload recommendations are filtered out from the engine results."""
     sut = RuleProcessingPublisher("outgoing_topic", {"bootstrap.servers": "kafka:9092"})
     sut.producer = MagicMock()
     expected_output = json.dumps(expected_output) + "\n"

--- a/test/publishers/rule_processing_publisher_test.py
+++ b/test/publishers/rule_processing_publisher_test.py
@@ -420,3 +420,46 @@ def test_error(input, output):
     with patch("ccx_messaging.publishers.kafka_publisher.log") as log_mock:
         sut.error(input, None)
         assert log_mock.error.called
+
+
+VALID_REPORTS = [
+    pytest.param(
+        json.dumps({
+            "version": 1,
+            "reports": [],
+            "pass": [],
+            "info": [],
+            "workload_recommendations": []
+        }),
+        {
+            "OrgID": 10,
+            "AccountNumber": 1,
+            "ClusterName": "uuid",
+            "Report": {
+                "version": 1,
+                "reports": [],
+                "pass": [],
+                "info": []
+            },
+            "LastChecked": "a timestamp",
+            "Version": 2,
+            "RequestId": "a request id",
+            "Metadata": {
+                "gathering_time": "2012-01-14T00:00:00Z"
+            }
+        },
+        id="valid_report"
+    )
+]
+
+
+@freezegun.freeze_time("2012-01-14")
+@pytest.mark.parametrize("input,expected_output", VALID_REPORTS)
+def test_filter_ocp_rules_results(input, expected_output):
+    sut = RuleProcessingPublisher("outgoing_topic", {"bootstrap.servers": "kafka:9092"})
+    sut.producer = MagicMock()
+    expected_output = json.dumps(expected_output) + "\n"
+
+    sut.publish(VALID_INPUT_MSG[0][0][0], input)
+    sut.producer.produce.assert_called_with("outgoing_topic", expected_output.encode())
+


### PR DESCRIPTION
# Description

Add filters both for DVO reports in `dvo_metrics_publisher.py` and for OCP reports in `rule_processing_publisher.py`.

## Type of change

- New feature (non-breaking change which adds functionality)
- Unit tests (no changes in the code)

## Testing steps

Run the unit tests for both publishers.

## Checklist
* [ ] `make before_commit` passes
* [ ] updated documentation wherever necessary
* [x] added or modified tests if necessary
* [ ] updated schemas and validators in [insights-data-schemas](https://github.com/RedHatInsights/insights-data-schemas) in case of input/output change
