### PR TITLE
[CCXDEV-11808] Remove all the f-strings from the exceptions

### DIFF
--- a/ccx_messaging/consumers/kafka_consumer.py
+++ b/ccx_messaging/consumers/kafka_consumer.py
@@ -111,7 +111,8 @@ class KafkaConsumer(Consumer):
         # The `handles` method should prevent this from
         # being called if the input message format is wrong.
         except Exception as ex:
-            raise CCXMessagingError(f"Unable to extract URL from input message: {ex}") from ex
+            LOG.error("Unable to extract URL from input message: %s", ex)
+            raise CCXMessagingError("Unable to extract URL from input message") from ex
 
     def run(self):
         """Consume message and proccess."""

--- a/ccx_messaging/downloaders/http_downloader.py
+++ b/ccx_messaging/downloaders/http_downloader.py
@@ -93,7 +93,8 @@ class HTTPDownloader:
         """Download a file from HTTP server and store it in a temporary file."""
         if not self.allow_unsafe_links:
             if src is None or not HTTPDownloader.HTTP_RE.fullmatch(src):
-                raise CCXMessagingError(f"Invalid URL format: {src}")
+                LOG.error("Invalid URL format: %s", src)
+                raise CCXMessagingError("Invalid URL format")
 
         try:
             response = requests.get(src)
@@ -101,12 +102,12 @@ class HTTPDownloader:
             size = len(data)
 
             if size == 0:
-                raise CCXMessagingError(f"Empty input archive from {src}")
+                LOG.error("Empty input archive from: %s", src)
+                raise CCXMessagingError("Empty input archive")
 
             if self.max_archive_size is not None and size > self.max_archive_size:
-                raise CCXMessagingError(
-                    f"The archive is too big ({size} > {self.max_archive_size}). Skipping"
-                )
+                LOG.error("The archive is too big ({size} > {self.max_archive_size})", size=size)
+                raise CCXMessagingError("The archive is too big. Skipping")
 
             with NamedTemporaryFile() as file_data:
                 file_data.write(data)

--- a/ccx_messaging/error.py
+++ b/ccx_messaging/error.py
@@ -28,8 +28,5 @@ class CCXMessagingError(Exception):
         return (
             f"Status: Error; "
             f"Topic: {input_msg['topic']}; "
-            f"Partition: {input_msg['partition']}; "
-            f"Offset: {input_msg['offset']}; "
-            f"Cluster: {input_msg['cluster_name']}; "
             f"Cause: {self}"
         )

--- a/ccx_messaging/ingress.py
+++ b/ccx_messaging/ingress.py
@@ -24,18 +24,20 @@ def parse_identity(encoded_identity: bytes) -> dict:
         return identity
 
     except TypeError as ex:
-        raise CCXMessagingError("Bad argument type %s", encoded_identity) from ex
+        LOG.error("Bad argument type %s", encoded_identity)
+        raise CCXMessagingError("Bad argument type") from ex
 
     except binascii.Error as ex:
-        raise CCXMessagingError(
-            f"Base64 encoded identity could not be parsed: {encoded_identity}"
-        ) from ex
+        LOG.error("Base64 encoded identity could not be parsed: %s", encoded_identity)
+        raise CCXMessagingError("Base64 encoded identity could not be parsed") from ex
 
     except json.JSONDecodeError as ex:
-        raise CCXMessagingError(f"Unable to decode received message: {decoded_identity}") from ex
+        LOG.error("Unable to decode received message: %s", decoded_identity)
+        raise CCXMessagingError("Unable to decode received message") from ex
 
     except jsonschema.ValidationError as ex:
-        raise CCXMessagingError(f"Invalid input message JSON schema: {identity}") from ex
+        LOG.error("Invalid input message JSON schema: %s", identity)
+        raise CCXMessagingError("Invalid input message JSON schema") from ex
 
 
 def parse_ingress_message(message: bytes) -> dict:
@@ -45,15 +47,16 @@ def parse_ingress_message(message: bytes) -> dict:
         jsonschema.validate(instance=deserialized_message, schema=INPUT_MESSAGE_SCHEMA)
 
     except TypeError as ex:
-        raise CCXMessagingError(f"Incorrect message type: {message}") from ex
+        LOG.error("Incorrect message type: %s", message)
+        raise CCXMessagingError("Incorrect message type") from ex
 
     except json.JSONDecodeError as ex:
-        raise CCXMessagingError(f"Unable to decode received message: {message}") from ex
+        LOG.error("Unable to decode received message: %s", message)
+        raise CCXMessagingError("Unable to decode received message") from ex
 
     except jsonschema.ValidationError as ex:
-        raise CCXMessagingError(
-            f"Invalid input message JSON schema: {deserialized_message}"
-        ) from ex
+        LOG.error("Invalid input message JSON schema: %s", deserialized_message)
+        raise CCXMessagingError("Invalid input message JSON schema") from ex
 
     LOG.debug("JSON schema validated: %s", deserialized_message)
 

--- a/ccx_messaging/publishers/dvo_metrics_publisher.py
+++ b/ccx_messaging/publishers/dvo_metrics_publisher.py
@@ -41,24 +41,25 @@ class DVOMetricsPublisher(KafkaPublisher):
 
         try:
             report = json.loads(report)
-        except (TypeError, json.decoder.JSONDecodeError):
-            raise CCXMessagingError("Could not parse report; report is not in JSON format")
+        except (TypeError, json.decoder.JSONDecodeError) as err:
+            raise CCXMessagingError("Could not parse report; report is not in JSON format") from err
 
         report.pop("reports", None)
 
         try:
             org_id = int(input_msg["identity"]["identity"]["internal"]["org_id"])
         except (ValueError, KeyError, TypeError) as err:
-            raise CCXMessagingError(f"Error extracting the OrgID: {err}") from err
+            log.error("Error extracting the OrgID: %s", err)
+            raise CCXMessagingError("Error extracting the OrgID") from err
 
         try:
             account_number = int(input_msg["identity"]["identity"]["account_number"])
         except (ValueError, KeyError, TypeError) as err:
-            log.warning(f"Error extracting the Account number: {err}")
+            log.warning("Error extracting the Account number: %s", err)
             account_number = ""
 
         if "cluster_name" not in input_msg:
-            raise CCXMessagingError()
+            raise CCXMessagingError("Can't find 'cluster_name'")
 
         output_msg = {
             "OrgID": org_id,

--- a/ccx_messaging/publishers/rule_processing_publisher.py
+++ b/ccx_messaging/publishers/rule_processing_publisher.py
@@ -93,12 +93,13 @@ class RuleProcessingPublisher(KafkaPublisher):
         try:
             org_id = int(input_msg["identity"]["identity"]["internal"]["org_id"])
         except (ValueError, KeyError, TypeError) as err:
-            raise CCXMessagingError(f"Error extracting the OrgID: {err}") from err
+            log.error("Error extracting the OrgID: %s", err)
+            raise CCXMessagingError("Error extracting the OrgID") from err
 
         try:
             account_number = int(input_msg["identity"]["identity"]["account_number"])
         except (ValueError, KeyError, TypeError) as err:
-            log.warning(f"Error extracting the Account number: {err}")
+            log.warning("Error extracting the Account number: %s", err)
             account_number = ""
 
         try:
@@ -148,5 +149,5 @@ class RuleProcessingPublisher(KafkaPublisher):
             raise CCXMessagingError("Missing expected keys in the input message") from err
 
         except (TypeError, UnicodeEncodeError, JSONDecodeError) as err:
-            log.info(err)
-            raise CCXMessagingError(f"Error encoding the response to publish: {report}") from err
+            log.error(err)
+            raise CCXMessagingError("Error encoding the response to publish") from err

--- a/ccx_messaging/publishers/workloads_info_publisher.py
+++ b/ccx_messaging/publishers/workloads_info_publisher.py
@@ -57,12 +57,13 @@ class WorkloadInfoPublisher(KafkaPublisher):
         try:
             org_id = int(input_msg["identity"]["identity"]["internal"]["org_id"])
         except (ValueError, TypeError, KeyError) as err:
-            raise CCXMessagingError(f"Error extracting the OrgID: {err}") from err
+            log.error("Error extracting the OrgID: %s", err)
+            raise CCXMessagingError("Error extracting the OrgID") from err
 
         try:
             account_number = int(input_msg["identity"]["identity"]["account_number"])
         except (ValueError, KeyError, TypeError) as err:
-            log.warning(f"Error extracting the Account number: {err}")
+            log.warning("Error extracting the Account number: %s", err)
             account_number = ""
 
         # outgoing message in form of JSON
@@ -116,4 +117,5 @@ class WorkloadInfoPublisher(KafkaPublisher):
             )
 
         except (KeyError, TypeError, UnicodeEncodeError, JSONDecodeError) as err:
-            raise CCXMessagingError(f"Error encoding the response to publish: {message}") from err
+            log.error("Error encoding the response to publish: %s", message)
+            raise CCXMessagingError("Error encoding the response to publish") from err

--- a/test/downloaders/http_downloader_test.py
+++ b/test/downloaders/http_downloader_test.py
@@ -37,7 +37,7 @@ def test_parse_human_input_valid_file_sizes(file_size):
     parse_human_input(file_size)
 
 
-_REGEX_BAD_URL_FORMAT = r"^Invalid URL format: .*"
+_REGEX_BAD_URL_FORMAT = r"^Invalid URL format"
 _INVALID_TYPE_URLS = [42, 2.71, True, [], {}]
 
 @pytest.mark.parametrize("url", _INVALID_TYPE_URLS)

--- a/test/downloaders/http_downloader_test.py
+++ b/test/downloaders/http_downloader_test.py
@@ -18,13 +18,27 @@ from unittest.mock import MagicMock, patch
 
 import pytest
 
-from ccx_messaging.downloaders.http_downloader import HTTPDownloader
+from ccx_messaging.downloaders.http_downloader import HTTPDownloader, parse_human_input
 from ccx_messaging.error import CCXMessagingError
+
+
+_INVALID_FILE_SIZES = [42, 2.71, True, [], {}, "1234J"]
+_VALID_FILE_SIZES = ["1K", "2M", "3G", "4T", "5Ki", "6Mi", "7Gi", "8Ti"]
+
+@pytest.mark.parametrize("file_size", _INVALID_FILE_SIZES)
+def test_parse_human_input_invalid_file_sizes(file_size):
+    """Test that passing invalid data to parse_human_input raise an exception."""
+    with pytest.raises((TypeError, ValueError)):
+        parse_human_input(file_size)
+
+@pytest.mark.parametrize("file_size", _VALID_FILE_SIZES)
+def test_parse_human_input_valid_file_sizes(file_size):
+    """Test that passing valid data to parse_human_input doesn't raise an exception."""
+    parse_human_input(file_size)
 
 
 _REGEX_BAD_URL_FORMAT = r"^Invalid URL format: .*"
 _INVALID_TYPE_URLS = [42, 2.71, True, [], {}]
-
 
 @pytest.mark.parametrize("url", _INVALID_TYPE_URLS)
 def test_get_invalid_type(url):

--- a/test/error_test.py
+++ b/test/error_test.py
@@ -35,7 +35,6 @@ def test_error_formatting():
 
     fmt = err.format(input_msg)
     expected = (
-        "Status: Error; Topic: topic name; Partition: partition name; "
-        + "Offset: 1234; Cluster: clusterName; Cause: CCXMessagingError"
+        "Status: Error; Topic: topic name; Cause: CCXMessagingError"
     )
     assert fmt == expected


### PR DESCRIPTION
# Description

Using f-strings in Exceptions is an anti pattern - see https://docs.astral.sh/ruff/rules/f-string-in-exception/ for example. This is creating a lot of duplication in Glitchtip making it impossible to integrate it with Jira. It will basically DDOS our Jira board.

In this PR I remove all the f-strings from the exceptions. I left the Exceptions in `parse_human_filesize` as the arguments there are not dynamically generated, but it could be dropped too.

Part of [CCXDEV-11808](https://issues.redhat.com/browse/CCXDEV-11808)

## Type of change

- Bug fix (non-breaking change which fixes an issue)

## Testing steps

CI.

## Checklist
* [ ] `make before_commit` passes
* [ ] updated documentation wherever necessary
* [ ] added or modified tests if necessary
* [ ] updated schemas and validators in [insights-data-schemas](https://github.com/RedHatInsights/insights-data-schemas) in case of input/output change
