### PR TITLE
[CCXDEV-12238] Fix bug with the kafka urls

### DIFF
--- a/ccx_messaging/utils/clowder.py
+++ b/ccx_messaging/utils/clowder.py
@@ -40,7 +40,7 @@ def apply_clowder_config(manifest):
     kafka_urls = app_common_python.KafkaServers
     logger.debug("Kafka URLs: %s", kafka_urls)
 
-    kafka_broker_config = {"bootstrap.servers": kafka_urls}
+    kafka_broker_config = {"bootstrap.servers": ",".join(kafka_urls)}
 
     if clowder_broker_config.cacert:
         # Current Kafka library is not able to handle the CA file, only a path to it


### PR DESCRIPTION
# Description

https://github.com/RedHatInsights/insights-ccx-messaging/pull/122 broke our stage environment because we are passing a Python list to the `bootstrap.servers` field in the Kafka configuration. See this log:

```
{"filename": "kafka_publisher.py", "lineno": 56, "process": 1, "levelname": "DEBUG", "asctime": "2023-12-06 19:54:59,077", "name": "ccx_messaging.publishers.kafka_publisher", "message": "Confluent Kafka consumer configuration arguments: Server: ['b-1.consoledotstage.9benzz.c3.kafka.us-east-1.amazonaws.com:9096', 'b-2.consoledotstage.9benzz.c3.kafka.us-east-1.amazonaws.com:9096', 'b-3.consoledotstage.9benzz.c3.kafka.us-east-1.amazonaws.com:9096']. Topic: ccx.image.sha.results. Security protocol: SASL_SSL."}
```

The server is
```
['b-1.consoledotstage.9benzz.c3.kafka.us-east-1.amazonaws.com:9096', 'b-2.consoledotstage.9benzz.c3.kafka.us-east-1.amazonaws.com:9096', 'b-3.consoledotstage.9benzz.c3.kafka.us-east-1.amazonaws.com:9096']
```

Looking at [this example](https://github.com/RedHatInsights/insights-storage-broker/commit/001959d533f74bf7985a72a5eb2a874cd2510af9#diff-c4d0a009209380b8c2edf1de7b6117b65d28d708b43e276c2d32d8ee36668bcaR6) from the CRC folks, it looks like we need to pass a string, not a list. In this PR I'm copying their code to create a string containing all the servers. Note that in this case the string would be:
```
"b-1.consoledotstage.9benzz.c3.kafka.us-east-1.amazonaws.com:9096,b-2.consoledotstage.9benzz.c3.kafka.us-east-1.amazonaws.com:9096,b-3.consoledotstage.9benzz.c3.kafka.us-east-1.amazonaws.com:9096"
```
No whitespaces, no quotes and no brackets.

## Type of change

- Bug fix (non-breaking change which fixes an issue)

## Testing steps

None.

## Checklist
* [ ] `make before_commit` passes
* [ ] updated documentation wherever necessary
* [ ] added or modified tests if necessary
* [ ] updated schemas and validators in [insights-data-schemas](https://github.com/RedHatInsights/insights-data-schemas) in case of input/output change
