### PR TITLE
[CCXDEV-11808] Don't use log.error as it also sends messages to glitchtip

### DIFF
--- a/ccx_messaging/consumers/kafka_consumer.py
+++ b/ccx_messaging/consumers/kafka_consumer.py
@@ -111,7 +111,7 @@ class KafkaConsumer(Consumer):
         # The `handles` method should prevent this from
         # being called if the input message format is wrong.
         except Exception as ex:
-            LOG.error("Unable to extract URL from input message: %s", ex)
+            LOG.warning("Unable to extract URL from input message: %s", ex)
             raise CCXMessagingError("Unable to extract URL from input message") from ex
 
     def run(self):

--- a/ccx_messaging/downloaders/http_downloader.py
+++ b/ccx_messaging/downloaders/http_downloader.py
@@ -93,7 +93,7 @@ class HTTPDownloader:
         """Download a file from HTTP server and store it in a temporary file."""
         if not self.allow_unsafe_links:
             if src is None or not HTTPDownloader.HTTP_RE.fullmatch(src):
-                LOG.error("Invalid URL format: %s", src)
+                LOG.warning("Invalid URL format: %s", src)
                 raise CCXMessagingError("Invalid URL format")
 
         try:
@@ -102,11 +102,11 @@ class HTTPDownloader:
             size = len(data)
 
             if size == 0:
-                LOG.error("Empty input archive from: %s", src)
+                LOG.warning("Empty input archive from: %s", src)
                 raise CCXMessagingError("Empty input archive")
 
             if self.max_archive_size is not None and size > self.max_archive_size:
-                LOG.error("The archive is too big ({size} > {self.max_archive_size})", size=size)
+                LOG.warning("The archive is too big ({size} > {self.max_archive_size})", size=size)
                 raise CCXMessagingError("The archive is too big. Skipping")
 
             with NamedTemporaryFile() as file_data:

--- a/ccx_messaging/ingress.py
+++ b/ccx_messaging/ingress.py
@@ -24,19 +24,19 @@ def parse_identity(encoded_identity: bytes) -> dict:
         return identity
 
     except TypeError as ex:
-        LOG.error("Bad argument type %s", encoded_identity)
+        LOG.warning("Bad argument type %s", encoded_identity)
         raise CCXMessagingError("Bad argument type") from ex
 
     except binascii.Error as ex:
-        LOG.error("Base64 encoded identity could not be parsed: %s", encoded_identity)
+        LOG.warning("Base64 encoded identity could not be parsed: %s", encoded_identity)
         raise CCXMessagingError("Base64 encoded identity could not be parsed") from ex
 
     except json.JSONDecodeError as ex:
-        LOG.error("Unable to decode received message: %s", decoded_identity)
+        LOG.warning("Unable to decode received message: %s", decoded_identity)
         raise CCXMessagingError("Unable to decode received message") from ex
 
     except jsonschema.ValidationError as ex:
-        LOG.error("Invalid input message JSON schema: %s", identity)
+        LOG.warning("Invalid input message JSON schema: %s", identity)
         raise CCXMessagingError("Invalid input message JSON schema") from ex
 
 
@@ -47,15 +47,15 @@ def parse_ingress_message(message: bytes) -> dict:
         jsonschema.validate(instance=deserialized_message, schema=INPUT_MESSAGE_SCHEMA)
 
     except TypeError as ex:
-        LOG.error("Incorrect message type: %s", message)
+        LOG.warning("Incorrect message type: %s", message)
         raise CCXMessagingError("Incorrect message type") from ex
 
     except json.JSONDecodeError as ex:
-        LOG.error("Unable to decode received message: %s", message)
+        LOG.warning("Unable to decode received message: %s", message)
         raise CCXMessagingError("Unable to decode received message") from ex
 
     except jsonschema.ValidationError as ex:
-        LOG.error("Invalid input message JSON schema: %s", deserialized_message)
+        LOG.warning("Invalid input message JSON schema: %s", deserialized_message)
         raise CCXMessagingError("Invalid input message JSON schema") from ex
 
     LOG.debug("JSON schema validated: %s", deserialized_message)

--- a/ccx_messaging/publishers/dvo_metrics_publisher.py
+++ b/ccx_messaging/publishers/dvo_metrics_publisher.py
@@ -49,7 +49,7 @@ class DVOMetricsPublisher(KafkaPublisher):
         try:
             org_id = int(input_msg["identity"]["identity"]["internal"]["org_id"])
         except (ValueError, KeyError, TypeError) as err:
-            log.error("Error extracting the OrgID: %s", err)
+            log.warning("Error extracting the OrgID: %s", err)
             raise CCXMessagingError("Error extracting the OrgID") from err
 
         try:

--- a/ccx_messaging/publishers/kafka_publisher.py
+++ b/ccx_messaging/publishers/kafka_publisher.py
@@ -92,4 +92,4 @@ class KafkaPublisher(Publisher):
         if not isinstance(ex, CCXMessagingError):
             ex = CCXMessagingError(ex)
 
-        log.error(ex.format(input_msg))
+        log.warning(ex.format(input_msg))

--- a/ccx_messaging/publishers/rule_processing_publisher.py
+++ b/ccx_messaging/publishers/rule_processing_publisher.py
@@ -93,7 +93,7 @@ class RuleProcessingPublisher(KafkaPublisher):
         try:
             org_id = int(input_msg["identity"]["identity"]["internal"]["org_id"])
         except (ValueError, KeyError, TypeError) as err:
-            log.error("Error extracting the OrgID: %s", err)
+            log.warning("Error extracting the OrgID: %s", err)
             raise CCXMessagingError("Error extracting the OrgID") from err
 
         try:
@@ -149,5 +149,5 @@ class RuleProcessingPublisher(KafkaPublisher):
             raise CCXMessagingError("Missing expected keys in the input message") from err
 
         except (TypeError, UnicodeEncodeError, JSONDecodeError) as err:
-            log.error(err)
+            log.warning(err)
             raise CCXMessagingError("Error encoding the response to publish") from err

--- a/ccx_messaging/publishers/workloads_info_publisher.py
+++ b/ccx_messaging/publishers/workloads_info_publisher.py
@@ -57,7 +57,7 @@ class WorkloadInfoPublisher(KafkaPublisher):
         try:
             org_id = int(input_msg["identity"]["identity"]["internal"]["org_id"])
         except (ValueError, TypeError, KeyError) as err:
-            log.error("Error extracting the OrgID: %s", err)
+            log.warning("Error extracting the OrgID: %s", err)
             raise CCXMessagingError("Error extracting the OrgID") from err
 
         try:
@@ -117,5 +117,5 @@ class WorkloadInfoPublisher(KafkaPublisher):
             )
 
         except (KeyError, TypeError, UnicodeEncodeError, JSONDecodeError) as err:
-            log.error("Error encoding the response to publish: %s", message)
+            log.warning("Error encoding the response to publish: %s", message)
             raise CCXMessagingError("Error encoding the response to publish") from err

--- a/test/publishers/dvo_metrics_publisher_test.py
+++ b/test/publishers/dvo_metrics_publisher_test.py
@@ -379,7 +379,7 @@ def test_error(input, output):
 
     with patch("ccx_messaging.publishers.kafka_publisher.log") as log_mock:
         sut.error(input, None)
-        assert log_mock.error.called
+        assert log_mock.warning.called
 
 
 VALID_REPORTS = [

--- a/test/publishers/rule_processing_publisher_test.py
+++ b/test/publishers/rule_processing_publisher_test.py
@@ -419,7 +419,7 @@ def test_error(input, output):
 
     with patch("ccx_messaging.publishers.kafka_publisher.log") as log_mock:
         sut.error(input, None)
-        assert log_mock.error.called
+        assert log_mock.warning.called
 
 
 VALID_REPORTS = [

--- a/test/publishers/workload_info_publisher_test.py
+++ b/test/publishers/workload_info_publisher_test.py
@@ -274,4 +274,4 @@ def test_error(input, output):
 
     with patch("ccx_messaging.publishers.kafka_publisher.log") as log_mock:
         sut.error(input, None)
-        assert log_mock.error.called
+        assert log_mock.warning.called


### PR DESCRIPTION
# Description

The default behaviour is to also send log.error messages to Sentry/Glitchtip ([see](https://docs.sentry.io/platforms/python/integrations/logging/)) so it's better to just use warning in these cases. See for example [this issue](https://glitchtip.devshift.net/insights/issues/1794587?project=35&sort=-last_seen&query=is:unresolved).

## Type of change

- Bug fix (non-breaking change which fixes an issue)

## Testing steps

CI

## Checklist
* [ ] `make before_commit` passes
* [ ] updated documentation wherever necessary
* [ ] added or modified tests if necessary
* [ ] updated schemas and validators in [insights-data-schemas](https://github.com/RedHatInsights/insights-data-schemas) in case of input/output change
