### PR TITLE
[CCXDEV-12445] Do not send the message without relevant results

### DIFF
--- a/ccx_messaging/publishers/dvo_metrics_publisher.py
+++ b/ccx_messaging/publishers/dvo_metrics_publisher.py
@@ -44,6 +44,10 @@ class DVOMetricsPublisher(KafkaPublisher):
         except (TypeError, json.decoder.JSONDecodeError) as err:
             raise CCXMessagingError("Could not parse report; report is not in JSON format") from err
 
+        if "workload_recommendations" not in report.keys():
+            log.info("Report does not contain DVO related results; skipping")
+            return
+
         report.pop("reports", None)
 
         try:

--- a/ccx_messaging/publishers/rule_processing_publisher.py
+++ b/ccx_messaging/publishers/rule_processing_publisher.py
@@ -87,6 +87,10 @@ class RuleProcessingPublisher(KafkaPublisher):
         except (TypeError, json.decoder.JSONDecodeError):
             raise CCXMessagingError("Could not parse report; report is not in JSON format")
 
+        if "reports" not in report.keys():
+            log.info("Report does not contain OCP rules related results; skipping")
+            return
+
         report.pop("workload_recommendations", None)
 
         output_msg = {}

--- a/test/publishers/dvo_metrics_publisher_test.py
+++ b/test/publishers/dvo_metrics_publisher_test.py
@@ -395,3 +395,14 @@ def test_filter_dvo_results(input, expected_output):
 
     sut.publish(VALID_INPUT_MSG[0][0][0], input)
     sut.producer.produce.assert_called_with("outgoing_topic", expected_output.encode())
+
+
+def test_empty_dvo_results():
+    """Check that the publisher does not send empty message."""
+    sut = DVOMetricsPublisher("outgoing_topic", {"bootstrap.servers": "kafka:9092"})
+    sut.producer = MagicMock()
+
+    input = json.dumps({"version": 1, "reports": [], "pass": [], "info": []})
+    sut.publish(VALID_INPUT_MSG[0][0][0], input)
+    assert not sut.producer.produce.called
+

--- a/test/publishers/dvo_metrics_publisher_test.py
+++ b/test/publishers/dvo_metrics_publisher_test.py
@@ -145,7 +145,7 @@ VALID_INPUT_MSG = [
             "OrgID": 10,
             "AccountNumber": 1,
             "ClusterName": "uuid",
-            "Metrics": {},
+            "Metrics": {"workload_recommendations": []},
             "RequestId": "a request id",
         },
         id="with account",
@@ -169,7 +169,7 @@ VALID_INPUT_MSG = [
             "OrgID": 10,
             "AccountNumber": "",
             "ClusterName": "uuid",
-            "Metrics": {},
+            "Metrics": {"workload_recommendations": []},
             "RequestId": "a request id",
         },
         id="invalid account",
@@ -193,7 +193,7 @@ VALID_INPUT_MSG = [
             "OrgID": 10,
             "AccountNumber": "",
             "ClusterName": "uuid",
-            "Metrics": {},
+            "Metrics": {"workload_recommendations": []},
             "RequestId": "a request id",
         },
         id="empty account",
@@ -216,7 +216,7 @@ VALID_INPUT_MSG = [
             "OrgID": 10,
             "AccountNumber": "",
             "ClusterName": "uuid",
-            "Metrics": {},
+            "Metrics": {"workload_recommendations": []},
             "RequestId": "a request id",
         },
         id="no account",
@@ -240,7 +240,7 @@ VALID_INPUT_MSG = [
             "OrgID": 10,
             "AccountNumber": "",
             "ClusterName": "uuid",
-            "Metrics": {},
+            "Metrics": {"workload_recommendations": []},
             "RequestId": "a request id",
         },
         id="with gathering timestamp",
@@ -264,7 +264,7 @@ VALID_INPUT_MSG = [
             "OrgID": 10,
             "AccountNumber": "",
             "ClusterName": "uuid",
-            "Metrics": {},
+            "Metrics": {"workload_recommendations": []},
             "RequestId": "a request id",
         },
         id="with gathering timestamp in ISO format",
@@ -288,7 +288,7 @@ VALID_INPUT_MSG = [
             "OrgID": 10,
             "AccountNumber": "",
             "ClusterName": "uuid",
-            "Metrics": {},
+            "Metrics": {"workload_recommendations": []},
             "RequestId": "a request id",
         },
         id="with custom metadata without gathering timestamp",
@@ -312,7 +312,7 @@ VALID_INPUT_MSG = [
             "OrgID": 10,
             "AccountNumber": "",
             "ClusterName": "uuid",
-            "Metrics": {},
+            "Metrics": {"workload_recommendations": []},
             "RequestId": "a request id",
         },
         id="empty metadata",
@@ -324,7 +324,7 @@ VALID_INPUT_MSG = [
 @pytest.mark.parametrize("input, expected_output", VALID_INPUT_MSG)
 def test_publish_valid(input, expected_output):
     """Check that Kafka producer is called with an expected message."""
-    report = "{}"
+    report = "{\"workload_recommendations\": []}"
 
     expected_output = json.dumps(expected_output) + "\n"
     sut = DVOMetricsPublisher("outgoing_topic", {"bootstrap.servers": "kafka:9092"})

--- a/test/publishers/rule_processing_publisher_test.py
+++ b/test/publishers/rule_processing_publisher_test.py
@@ -145,7 +145,7 @@ VALID_INPUT_MSG = [
             "OrgID": 10,
             "AccountNumber": 1,
             "ClusterName": "uuid",
-            "Report": {},
+            "Report": {"reports": []},
             "LastChecked": "a timestamp",
             "Version": 2,
             "RequestId": "a request id",
@@ -172,7 +172,7 @@ VALID_INPUT_MSG = [
             "OrgID": 10,
             "AccountNumber": "",
             "ClusterName": "uuid",
-            "Report": {},
+            "Report": {"reports": []},
             "LastChecked": "a timestamp",
             "Version": 2,
             "RequestId": "a request id",
@@ -199,7 +199,7 @@ VALID_INPUT_MSG = [
             "OrgID": 10,
             "AccountNumber": "",
             "ClusterName": "uuid",
-            "Report": {},
+            "Report": {"reports": []},
             "LastChecked": "a timestamp",
             "Version": 2,
             "RequestId": "a request id",
@@ -225,7 +225,7 @@ VALID_INPUT_MSG = [
             "OrgID": 10,
             "AccountNumber": "",
             "ClusterName": "uuid",
-            "Report": {},
+            "Report": {"reports": []},
             "LastChecked": "a timestamp",
             "Version": 2,
             "RequestId": "a request id",
@@ -252,7 +252,7 @@ VALID_INPUT_MSG = [
             "OrgID": 10,
             "AccountNumber": "",
             "ClusterName": "uuid",
-            "Report": {},
+            "Report": {"reports": []},
             "LastChecked": "a timestamp",
             "Version": 2,
             "RequestId": "a request id",
@@ -279,7 +279,7 @@ VALID_INPUT_MSG = [
             "OrgID": 10,
             "AccountNumber": "",
             "ClusterName": "uuid",
-            "Report": {},
+            "Report": {"reports": []},
             "LastChecked": "a timestamp",
             "Version": 2,
             "RequestId": "a request id",
@@ -306,7 +306,7 @@ VALID_INPUT_MSG = [
             "OrgID": 10,
             "AccountNumber": "",
             "ClusterName": "uuid",
-            "Report": {},
+            "Report": {"reports": []},
             "LastChecked": "a timestamp",
             "Version": 2,
             "RequestId": "a request id",
@@ -333,7 +333,7 @@ VALID_INPUT_MSG = [
             "OrgID": 10,
             "AccountNumber": "",
             "ClusterName": "uuid",
-            "Report": {},
+            "Report": {"reports": []},
             "LastChecked": "a timestamp",
             "Version": 2,
             "RequestId": "a request id",
@@ -348,7 +348,7 @@ VALID_INPUT_MSG = [
 @pytest.mark.parametrize("input, expected_output", VALID_INPUT_MSG)
 def test_publish_valid(input, expected_output):
     """Check that Kafka producer is called with an expected message."""
-    report = "{}"
+    report = "{\"reports\": []}"
 
     expected_output = json.dumps(expected_output) + "\n"
     sut = RuleProcessingPublisher("outgoing_topic", {"bootstrap.servers": "kafka:9092"})
@@ -423,3 +423,13 @@ def test_filter_ocp_rules_results(input, expected_output):
 
     sut.publish(VALID_INPUT_MSG[0][0][0], input)
     sut.producer.produce.assert_called_with("outgoing_topic", expected_output.encode())
+
+def test_empty_ocp_rules_results():
+    """Check that the publisher does not send empty message."""
+    sut = RuleProcessingPublisher("outgoing_topic", {"bootstrap.servers": "kafka:9092"})
+    sut.producer = MagicMock()
+
+    input = json.dumps({"version": 1, "workload_recommendations": [], "pass": [], "info": []})
+    sut.publish(VALID_INPUT_MSG[0][0][0], input)
+    assert not sut.producer.produce.called
+


### PR DESCRIPTION
# Description

Both rule processing publisher and dvo publisher can send messages without relevant results. Changes here prevent that.

## Type of change

- Bug fix (non-breaking change which fixes an issue)

## Testing steps

Tested with unit tests and locally - if rule processing publisher still produces messages (cannot do more, since DVO rules are still not applied to archive data).

## Checklist
* [x] `make before_commit` passes
* [ ] updated documentation wherever necessary
* [x] added or modified tests if necessary
* [ ] updated schemas and validators in [insights-data-schemas](https://github.com/RedHatInsights/insights-data-schemas) in case of input/output change
