### PR TITLE
[CCXDEV-12397] Fix producing messages to dead letter queue

### DIFF
--- a/ccx_messaging/consumers/kafka_consumer.py
+++ b/ccx_messaging/consumers/kafka_consumer.py
@@ -252,7 +252,8 @@ class KafkaConsumer(Consumer):
         if not self.dlq_producer:
             return
 
-        self.dlq_producer.send(
+        LOG.info("Sending the message to dead letter queue topic")
+        self.dlq_producer.produce(
             self.dead_letter_queue_topic,
             msg.value(),
         )

--- a/test/consumers/kafka_consumer_test.py
+++ b/test/consumers/kafka_consumer_test.py
@@ -451,7 +451,7 @@ def test_process_dead_letter_no_configured(value, expected):
     input_message = KafkaMessage(value)
 
     sut.process_dead_letter(input_message)
-    assert not sut.dlq_producer.send.called
+    assert not sut.dlq_producer.produce.called
 
 
 @pytest.mark.parametrize("value,expected", _VALID_MESSAGES)
@@ -470,7 +470,7 @@ def test_process_dead_letter_message(producer_init_mock, value, expected):
     message_mock.value.return_value = value
 
     sut.process_dead_letter(message_mock)
-    producer_mock.send.assert_called_with(dlq_topic_name, value)
+    producer_mock.produce.assert_called_with(dlq_topic_name, value)
 
 
 @patch("ccx_messaging.consumers.kafka_consumer.ConfluentConsumer")


### PR DESCRIPTION
# Description

Wrong method name was called in producer used for sending messages to dead letter queue.

## Type of change

- Bug fix (non-breaking change which fixes an issue)

## Testing steps

Tested locally.

## Checklist
* [ ] `make before_commit` passes
* [ ] updated documentation wherever necessary
* [ ] added or modified tests if necessary
* [ ] updated schemas and validators in [insights-data-schemas](https://github.com/RedHatInsights/insights-data-schemas) in case of input/output change
