### PR TITLE
[CCXDEV-12378] Automerge dependabot updates

### DIFF
--- a/.github/workflows/dependabot-automerge.yml
+++ b/.github/workflows/dependabot-automerge.yml
@@ -1,0 +1,27 @@
+# Set as automatically merge all the pull requests created by dependabot[bot]
+name: Dependabot auto-merge
+on: pull_request
+
+# This section adds write permissions to the secrets.GITHUB_TOKEN. Default is just read
+permissions:
+  contents: write
+  pull-requests: write
+
+jobs:
+  dependabot:
+    runs-on: ubuntu-latest
+    if: github.actor == 'dependabot[bot]'
+    steps:
+      - name: Dependabot metadata
+        id: metadata
+        uses: dependabot/fetch-metadata@v1
+        with:
+          github-token: "${{ secrets.GITHUB_TOKEN }}"
+      - name: Enable auto-merge for Dependabot PRs
+        # We can filter depending on the semver major, minor, or patch updates,
+        # but let's not do it for now
+        # if: steps.metadata.outputs.update-type == 'version-update:semver-patch'
+        run: gh pr merge --auto --merge "$PR_URL"
+        env:
+          PR_URL: ${{github.event.pull_request.html_url}}
+          GH_TOKEN: ${{secrets.GITHUB_TOKEN}}

--- a/.github/workflows/dependabot-automerge.yml
+++ b/.github/workflows/dependabot-automerge.yml
@@ -17,6 +17,11 @@ jobs:
         uses: dependabot/fetch-metadata@v1
         with:
           github-token: "${{ secrets.GITHUB_TOKEN }}"
+      - name: Approve a PR
+        run: gh pr review --approve "$PR_URL"
+        env:
+            PR_URL: ${{github.event.pull_request.html_url}}
+            GH_TOKEN: ${{secrets.GITHUB_TOKEN}}
       - name: Enable auto-merge for Dependabot PRs
         # We can filter depending on the semver major, minor, or patch updates,
         # but let's not do it for now


### PR DESCRIPTION
# Description

Set as automatically merge all the pull requests created by `dependabot[bot]`. I followed [these docs](https://docs.github.com/code-security/dependabot/working-with-dependabot/automating-dependabot-with-github-actions#enable-auto-merge-on-a-pull-request).

We can also filter on the semver major, minor, or patch updates, but let's not do it for now
```
if: steps.metadata.outputs.update-type == 'version-update:semver-patch'
```

## Type of change

- New feature (non-breaking change which adds functionality)

## Testing steps

TODO

## Checklist
* [ ] `pre-commit run -a` passes
* [ ] updated documentation wherever necessary
* [ ] added or modified tests if necessary
* [ ] updated schemas and validators in [insights-data-schemas](https://github.com/RedHatInsights/insights-data-schemas) in case of input/output change
