### PR TITLE
Adding Dockerfile for building container image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,28 @@
+FROM registry.access.redhat.com/ubi9-minimal:latest
+
+ENV VENV=/ccx-messaging-venv \
+    HOME=/insights-ccx-messaging \
+    REQUESTS_CA_BUNDLE=/etc/pki/tls/certs/ca-bundle.crt
+
+ENV PATH="$VENV/bin:$PATH"
+WORKDIR $HOME
+COPY . $HOME
+
+RUN curl -ksL https://certs.corp.redhat.com/certs/2015-IT-Root-CA.pem -o /etc/pki/ca-trust/source/anchors/RH-IT-Root-CA.crt && \
+    curl -ksL https://certs.corp.redhat.com/certs/2022-IT-Root-CA.pem -o /etc/pki/ca-trust/source/anchors/2022-IT-Root-CA.pem && \
+    update-ca-trust
+
+RUN microdnf install --nodocs -y python3.11 unzip tar git-core && \
+    python3.11 -m venv $VENV && \
+    pip install --no-cache-dir -U pip && \
+    pip install -r requirements.txt     \
+    pip install .
+
+RUN microdnf remove -y git-core && \
+    microdnf clean all && \
+    rpm -e --nodeps sqlite-libs krb5-libs libxml2 readline pam openssh openssh-clients
+
+RUN chmod -R g=u $HOME $VENV /etc/passwd && \
+    chgrp -R 0 $HOME $VENV
+
+USER 1001


### PR DESCRIPTION
# Description

Adding a `Dockerfile` in order to generate a container image with the minimal dependencies and able to run services that doesn't need any more dependencies than the ccx-messaging one.

## Type of change

- New feature (non-breaking change which adds functionality)

## Testing steps

N/A

## Checklist
* [ ] `pre-commit run -a` passes
* [ ] updated documentation wherever necessary
* [ ] added or modified tests if necessary
* [ ] updated schemas and validators in [insights-data-schemas](https://github.com/RedHatInsights/insights-data-schemas) in case of input/output change
