### PR TITLE
Removing old Python version checks

### DIFF
--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -10,9 +10,6 @@ jobs:
     strategy:
       matrix:
         python-version:
-          - "3.8"
-          - "3.9"
-          - "3.10"
           - "3.11"
           - "3.12"
     steps:
@@ -26,6 +23,6 @@ jobs:
       - run: tox -vv
       - name: Upload coverage
         uses: codecov/codecov-action@v4
-        if: ${{ matrix.python-version == '3.8' }}
+        if: ${{ matrix.python-version == '3.11' }}
         with:
           token: ${{ secrets.CODECOV_TOKEN }}

--- a/tox.ini
+++ b/tox.ini
@@ -1,6 +1,6 @@
 [tox]
 minversion = 3.18.0
-envlist = py{38,39,310,311,312}
+envlist = py{311,312}
 
 [testenv]
 setenv = PIP_CONSTRAINT=constraints.txt
@@ -21,6 +21,3 @@ max-line-length = 100
 python =
     3.12 = py312
     3.11 = py311
-    3.10 = py310
-    3.9 = py39
-    3.8 = py38


### PR DESCRIPTION
# Description

Removing Python prior to 3.11, as all the services using this library are using Python 3.11 or later.

(Commit to ensure proper configuration of CI)

## Type of change

- Bump-up dependent library (no changes in the code)

## Testing steps

N/A

## Checklist
* [ ] `pre-commit run -a` passes
* [ ] updated documentation wherever necessary
* [ ] added or modified tests if necessary
* [ ] updated schemas and validators in [insights-data-schemas](https://github.com/RedHatInsights/insights-data-schemas) in case of input/output change
