### PR TITLE
[CCXDEV-12378] Add a second approbal by InsightsDroid

### DIFF
--- a/.github/workflows/dependabot-automerge.yml
+++ b/.github/workflows/dependabot-automerge.yml
@@ -17,11 +17,16 @@ jobs:
         uses: dependabot/fetch-metadata@v1
         with:
           github-token: "${{ secrets.GITHUB_TOKEN }}"
-      - name: Approve a PR
+      - name: Github Actions bot approves the PR
         run: gh pr review --approve "$PR_URL"
         env:
             PR_URL: ${{github.event.pull_request.html_url}}
             GH_TOKEN: ${{secrets.GITHUB_TOKEN}}
+      - name: InsightsDroid approves the PR
+        run: gh pr review --approve "$PR_URL"
+        env:
+          PR_URL: ${{github.event.pull_request.html_url}}
+          GH_TOKEN: ${{secrets.INSIGHTSDROID_TOKEN}}
       - name: Enable auto-merge for Dependabot PRs
         # We can filter depending on the semver major, minor, or patch updates,
         # but let's not do it for now


### PR DESCRIPTION
# Description

In https://github.com/RedHatInsights/insights-ccx-messaging/pull/166 I tried to automerge the dependabot PRs. However, our policy for merging is having at least 2 approvals. We need a second bot approving these PRs so that they can be automatically merged.

The secret was added using `gh secret set INSIGHTSDROID_TOKEN`

## Type of change

- New feature (non-breaking change which adds functionality)

## Testing steps

TODO: I need this to be merged before being able to tell if it works.

## Checklist
* [ ] `pre-commit run -a` passes
* [ ] updated documentation wherever necessary
* [ ] added or modified tests if necessary
* [ ] updated schemas and validators in [insights-data-schemas](https://github.com/RedHatInsights/insights-data-schemas) in case of input/output change
