### PR TITLE
Create the broker with specific info needed by custom engine

### DIFF
--- a/ccx_messaging/consumers/idp_kafka_consumer.py
+++ b/ccx_messaging/consumers/idp_kafka_consumer.py
@@ -4,6 +4,8 @@ from confluent_kafka import Message
 from ccx_messaging.consumers.kafka_consumer import KafkaConsumer
 import json
 
+from insights import dr
+
 from ccx_messaging.error import CCXMessagingError
 
 LOG = logging.getLogger(__name__)
@@ -47,3 +49,10 @@ class IDPConsumer(KafkaConsumer):
 
         LOG.debug("JSON schema validated: %s", deserialized_message)
         return deserialized_message
+
+    def create_broker(self, input_msg):
+        """Create a suitable `Broker` to be pass arguments to the `Engine`."""
+        broker = dr.Broker()
+        broker["cluster_id"] = input_msg.get("cluster_id")
+        broker["s3_path"] = input_msg.get("path")
+        return broker


### PR DESCRIPTION
# Description

The default broker generated by the ICM `KafkaConsumer` method is empty, but the `IDPConsumer` needs to pass some relevant info to the engines.

## Type of change

- Bug fix (non-breaking change which fixes an issue)

## Testing steps

Run `ccx-messaging` locally with some testing input and realised that the engine cannot work because the lack of those keys in it.

## Checklist
* [x] `pre-commit run -a` passes
* [ ] updated documentation wherever necessary
* [ ] added or modified tests if necessary
* [ ] updated schemas and validators in [insights-data-schemas](https://github.com/RedHatInsights/insights-data-schemas) in case of input/output change
