### PR TITLE
Revert "Update boto3 requirement from <1.34.52,>=1.34.1 to >=1.34.1,<1.34.65"

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -25,7 +25,7 @@ classifiers = [
 requires-python = ">= 3.8"
 dependencies = [
     "app-common-python>=0.2.3",
-    "boto3>=1.34.1,<1.34.65",  # limited due to incompatibility between s3fs and newer versions of boto
+    "boto3>=1.34.1,<1.34.52",  # limited due to incompatibility between s3fs and newer versions of boto
     "confluent-kafka>=2.0.0",
     "insights-core>=3.1.2",
     "insights-core-messaging>=1.2.10",

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,5 @@
 app-common-python>=0.2.3
-boto3>=1.34.1,<1.34.65
+boto3>=1.34.1,<1.34.52
 confluent-kafka>=2.0.0
 insights-core>=3.1.2
 insights-core-messaging @ git+https://github.com/RedHatInsights/insights-core-messaging@1.2.10


### PR DESCRIPTION
Reverts RedHatInsights/insights-ccx-messaging#165

Let's rever it so that we can check https://github.com/RedHatInsights/insights-ccx-messaging/pull/170 works.