### PR TITLE
New multiplexor engine

### DIFF
--- a/ccx_messaging/engines/multiplexor_engine.py
+++ b/ccx_messaging/engines/multiplexor_engine.py
@@ -1,0 +1,58 @@
+# Copyright 2024 Red Hat, Inc
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Module that defines an Engine class for selecting where to publish a received archive."""
+
+import tarfile
+
+from insights.core.dr import Broker
+from insights.formats import Formatter
+from insights_messaging.engine import Engine
+
+
+class MultiplexorEngine(Engine):
+    """Engine that will create a report with the identified content of the archive."""
+
+    def __init__(
+        self,
+        formatter: Formatter,
+        target_components: list,
+        extract_timeout: int | None,
+        extract_tmp_dir: str | None,
+        filters: dict[str, str] | None = None,
+    ):
+        """Initialise the engine with the given filters.
+
+        The `filter` argument is a dictionary where the keys are a path and the value, a mark.
+        If a file with the given path is present inside the archive, it will be noted with
+        the given "mark". An archive could have several matching files, so it could get a buch
+        of different marks.
+        """
+        super().__init__(formatter, target_components, extract_timeout, extract_tmp_dir)
+        self.filters = filters if filters is not None else {}
+
+    def process(self, _: Broker, path: str) -> set[str]:
+        """Open an archive to check its content and classify it according to filters."""
+        with tarfile.open(path) as tf:
+            filenames = tf.getnames()
+
+            marks = set()
+            for file_to_find, mark in self.filters.items():
+                if file_to_find in filenames:
+                    marks.add(mark)
+
+        if not marks:
+            marks.add("DEFAULT")
+
+        return marks

--- a/ccx_messaging/engines/multiplexor_engine.py
+++ b/ccx_messaging/engines/multiplexor_engine.py
@@ -36,7 +36,7 @@ class MultiplexorEngine(Engine):
 
         The `filter` argument is a dictionary where the keys are a path and the value, a mark.
         If a file with the given path is present inside the archive, it will be noted with
-        the given "mark". An archive could have several matching files, so it could get a buch
+        the given "mark". An archive could have several matching files, so it could get a bunch
         of different marks.
         """
         super().__init__(formatter, target_components, extract_timeout, extract_tmp_dir)

--- a/test/engines/multiplexor_engine_test.py
+++ b/test/engines/multiplexor_engine_test.py
@@ -1,0 +1,108 @@
+# Copyright 2024 Red Hat, Inc
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Module for testing the engines module."""
+
+import pytest
+from insights.formats.text import HumanReadableFormat
+
+from ccx_messaging.engines.multiplexor_engine import MultiplexorEngine
+
+
+def test_init():
+    """Test the MultiplexorEngine initializer."""
+    sut = MultiplexorEngine(HumanReadableFormat, [], None, 10)
+
+    # just basic check
+    assert isinstance(sut, MultiplexorEngine)
+
+
+def test_process_no_extract():
+    """Basic test for MultiplexorEngine."""
+    sut = MultiplexorEngine(HumanReadableFormat, [], None, 10)
+    sut.watchers = []
+    sut.extract_tmp_dir = "not-exist"
+
+    broker = None
+    path = "not-exist"
+
+    with pytest.raises(Exception):
+        sut.process(broker, path)
+
+
+def test_process_no_filters():
+    """Basic test for MultiplexorEngine."""
+    sut = MultiplexorEngine(HumanReadableFormat, [], None, 10)
+    sut.watchers = []
+    sut.extract_tmp_dir = ""
+
+    broker = None
+    path = "test/wrong_data.tar"  # this file should be marked as "DEFAULT"
+
+    result = sut.process(broker, path)
+    assert result == {"DEFAULT"}
+
+
+def test_process_filters_no_match():
+    """Basic test for MultiplexorEngine."""
+    filters = {
+        "non-existing-file": "SHOULDNT MARK",
+    }
+    sut = MultiplexorEngine(HumanReadableFormat, [], None, 10, filters=filters)
+    sut.watchers = []
+    sut.extract_tmp_dir = ""
+
+    broker = None
+    path = "test/wrong_data.tar"  # this file should be marked as "DEFAULT"
+
+    result = sut.process(broker, path)
+    assert result == {"DEFAULT"}
+
+
+def test_process_filters_match():
+    """Basic test for MultiplexorEngine."""
+    expected_mark = "WORKLOAD_INFO"
+
+    filters = {
+        "data/config/workload_info.json": expected_mark,
+    }
+    sut = MultiplexorEngine(HumanReadableFormat, [], None, 10, filters=filters)
+    sut.watchers = []
+    sut.extract_tmp_dir = ""
+
+    broker = None
+    path = "test/wrong_data.tar"  # this file should be marked as "DEFAULT"
+
+    result = sut.process(broker, path)
+    assert result == {expected_mark}
+
+
+def test_process_several_matches():
+    """Basic test for SHAExtractorEngine."""
+    filters = {
+        "config": "IO",
+        "config/workload_info.json": "WORKLOAD_INFO",
+    }
+
+    sut = MultiplexorEngine(HumanReadableFormat, [], None, 10, filters=filters)
+    sut.watchers = []
+    sut.extract_tmp_dir = ""
+
+    broker = None
+    path = "test/correct_data.tar"
+
+    result = sut.process(broker, path)
+    assert "IO" in result
+    assert "WORKLOAD_INFO" in result
+    assert len(result) == 2


### PR DESCRIPTION
# Description

Adding a "multiplexor" engine. It will take a filter as a configuration parameter. Then, it will open the provided archive from the `path` argument, open the tarball find and seek files with a relative path specified in the filters dictionary, marking each archive with 1 or more "marks" to be processed by an enabled publisher.

Fixes #[CCXDEV-12640](https://issues.redhat.com/browse/CCXDEV-12640)

## Type of change

- New feature (non-breaking change which adds functionality)
- Breaking change (fix or feature that would cause existing functionality to not work as expected)
- Unit tests (no changes in the code)

## Testing steps

Tested locally with provided unit tests + local deployment using Minio and Kafka to perform some operations

## Checklist
* [x] `pre-commit run -a` passes
* [ ] updated documentation wherever necessary
* [x] added or modified tests if necessary
* [x] updated schemas and validators in [insights-data-schemas](https://github.com/RedHatInsights/insights-data-schemas) in case of input/output change
