### PR TITLE
Fix minor bug that can cause a missing Kafka initialization

### DIFF
--- a/ccx_messaging/consumers/idp_kafka_consumer.py
+++ b/ccx_messaging/consumers/idp_kafka_consumer.py
@@ -24,7 +24,7 @@ class IDPConsumer(KafkaConsumer):
         """Initialise the KafkaConsumer object and related handlers."""
         kwargs.pop("requeuer", None)
         incoming_topic = kwargs.pop("incoming_topic")
-        super().__init__(publisher, downloader, engine, incoming_topic, kwargs)
+        super().__init__(publisher, downloader, engine, incoming_topic, **kwargs)
 
     def get_url(self, input_msg: dict) -> str:
         """Retrieve URL to storage from Kafka message."""


### PR DESCRIPTION
# Description

Minor error in the handling of `kwargs` argument in the child class that, depending on the circumstances, can make the Kafka initialization to fail and is already causing a misleading info log message

## Type of change
- Bug fix (non-breaking change which fixes an issue)

## Testing steps

Tested locally with `tox`

## Checklist
* [x] `pre-commit run -a` passes
* [ ] updated documentation wherever necessary
* [ ] added or modified tests if necessary
* [ ] updated schemas and validators in [insights-data-schemas](https://github.com/RedHatInsights/insights-data-schemas) in case of input/output change
