### PR TITLE
Capturing the exception and raising an appropriate one

### DIFF
--- a/ccx_messaging/consumers/kafka_consumer.py
+++ b/ccx_messaging/consumers/kafka_consumer.py
@@ -196,7 +196,7 @@ class KafkaConsumer(Consumer):
 
         except CCXMessagingError as ex:
             LOG.warning(
-                "Unexpected error deserializing incoming message. (%s): %s. Error: %s",
+                "Unexpected error processing incoming message. (%s): %s. Error: %s",
                 self.log_pattern,
                 msg.value(),
                 ex,


### PR DESCRIPTION
# Description

Currently the exception is being raised, captured and re-raised, captured again and printed with `log.exception`, which shown the error in Sentry.

This approach will convert the `tarfile.ReadError` into a `CCXMessagingError` that will be shown, but not as a traceback, causing Sentry to don't care about it

Fixes #[CCXDEV-12711](https://issues.redhat.com/browse/CCXDEV-12711)

## Type of change

- Bug fix (non-breaking change which fixes an issue)

## Testing steps

Tested in a local deployment

## Checklist
* [x] `pre-commit run -a` passes
* [ ] updated documentation wherever necessary
* [ ] added or modified tests if necessary
* [ ] updated schemas and validators in [insights-data-schemas](https://github.com/RedHatInsights/insights-data-schemas) in case of input/output change
