### PR TITLE
Add label for differentiating OCP and HyperShift archives

### DIFF
--- a/test/watchers/stats_watcher_test.py
+++ b/test/watchers/stats_watcher_test.py
@@ -19,10 +19,20 @@ from unittest.mock import patch
 import pytest
 import time
 
-from ccx_messaging.watchers.stats_watcher import StatsWatcher, ARCHIVE_TYPE_LABEL, ARCHIVE_TYPE_VALUES
+from ccx_messaging.watchers.stats_watcher import (
+    StatsWatcher,
+    ARCHIVE_TYPE_LABEL,
+    ARCHIVE_TYPE_VALUES,
+)
 
 
 _INVALID_PORTS = [None, "8000", 8000.0, 70000]
+
+
+@pytest.fixture(params=ARCHIVE_TYPE_VALUES)
+def label_value(request):
+    """Set the label value for the running test."""
+    return request.param
 
 
 @pytest.mark.parametrize("value", _INVALID_PORTS)
@@ -34,10 +44,6 @@ def test_stats_watcher_initialize_invalid_port(value):
 
 _VALID_PORTS = [{}, {"prometheus_port": 9500}, {"prometheus_port": 80}]
 
-
-@pytest.fixture(params=ARCHIVE_TYPE_VALUES)
-def label_value(request):
-    return request.param
 
 @pytest.mark.parametrize("value", _VALID_PORTS)
 @patch("ccx_messaging.watchers.stats_watcher.start_http_server")
@@ -53,10 +59,21 @@ def check_initial_metrics_state(w):
     for value in ARCHIVE_TYPE_VALUES:
         assert w._recv_total._value.get() == 0
         assert w._filtered_total._value.get() == 0
-        assert w._extracted_total.labels(**{ARCHIVE_TYPE_LABEL: value})._value.get() == 0
-        assert w._processed_total.labels(**{ARCHIVE_TYPE_LABEL: value})._value.get() == 0
-        assert w._processed_timeout_total.labels(**{ARCHIVE_TYPE_LABEL: value})._value.get() == 0
-        assert w._published_total.labels(**{ARCHIVE_TYPE_LABEL: value})._value.get() == 0
+        assert (
+            w._extracted_total.labels(**{ARCHIVE_TYPE_LABEL: value})._value.get() == 0
+        )
+        assert (
+            w._processed_total.labels(**{ARCHIVE_TYPE_LABEL: value})._value.get() == 0
+        )
+        assert (
+            w._processed_timeout_total.labels(
+                **{ARCHIVE_TYPE_LABEL: value}
+            )._value.get()
+            == 0
+        )
+        assert (
+            w._published_total.labels(**{ARCHIVE_TYPE_LABEL: value})._value.get() == 0
+        )
         assert w._failures_total.labels(**{ARCHIVE_TYPE_LABEL: value})._value.get() == 0
         assert w._not_handling_total._value.get() == 0
         # Check initial values of histogram metrics
@@ -95,10 +112,21 @@ def test_stats_watcher_on_recv(label_value):
     assert w._recv_total._value.get() == 1
     assert w._filtered_total._value.get() == 0
     assert len(w._downloaded_total._labelvalues) == 0
-    assert w._processed_total.labels(**{ARCHIVE_TYPE_LABEL: label_value})._value.get() == 0
-    assert w._processed_timeout_total.labels(**{ARCHIVE_TYPE_LABEL: label_value})._value.get() == 0
-    assert w._published_total.labels(**{ARCHIVE_TYPE_LABEL: label_value})._value.get() == 0
-    assert w._failures_total.labels(**{ARCHIVE_TYPE_LABEL: label_value})._value.get() == 0
+    assert (
+        w._processed_total.labels(**{ARCHIVE_TYPE_LABEL: label_value})._value.get() == 0
+    )
+    assert (
+        w._processed_timeout_total.labels(
+            **{ARCHIVE_TYPE_LABEL: label_value}
+        )._value.get()
+        == 0
+    )
+    assert (
+        w._published_total.labels(**{ARCHIVE_TYPE_LABEL: label_value})._value.get() == 0
+    )
+    assert (
+        w._failures_total.labels(**{ARCHIVE_TYPE_LABEL: label_value})._value.get() == 0
+    )
     assert w._not_handling_total._value.get() == 0
 
 
@@ -120,10 +148,21 @@ def test_stats_watcher_on_filter(label_value):
     assert w._recv_total._value.get() == 0
     assert w._filtered_total._value.get() == 1
     assert w._downloaded_total._sum.get() == 0
-    assert w._processed_total.labels(**{ARCHIVE_TYPE_LABEL: label_value})._value.get() == 0
-    assert w._processed_timeout_total.labels(**{ARCHIVE_TYPE_LABEL: label_value})._value.get() == 0
-    assert w._published_total.labels(**{ARCHIVE_TYPE_LABEL: label_value})._value.get() == 0
-    assert w._failures_total.labels(**{ARCHIVE_TYPE_LABEL: label_value})._value.get() == 0
+    assert (
+        w._processed_total.labels(**{ARCHIVE_TYPE_LABEL: label_value})._value.get() == 0
+    )
+    assert (
+        w._processed_timeout_total.labels(
+            **{ARCHIVE_TYPE_LABEL: label_value}
+        )._value.get()
+        == 0
+    )
+    assert (
+        w._published_total.labels(**{ARCHIVE_TYPE_LABEL: label_value})._value.get() == 0
+    )
+    assert (
+        w._failures_total.labels(**{ARCHIVE_TYPE_LABEL: label_value})._value.get() == 0
+    )
     assert w._not_handling_total._value.get() == 0
 
 
@@ -146,10 +185,21 @@ def test_stats_watcher_on_download(label_value):
     assert w._recv_total._value.get() == 0
     assert w._filtered_total._value.get() == 0
     assert w._downloaded_total._sum.get() == 100
-    assert w._processed_total.labels(**{ARCHIVE_TYPE_LABEL: label_value})._value.get() == 0
-    assert w._processed_timeout_total.labels(**{ARCHIVE_TYPE_LABEL: label_value})._value.get() == 0
-    assert w._published_total.labels(**{ARCHIVE_TYPE_LABEL: label_value})._value.get() == 0
-    assert w._failures_total.labels(**{ARCHIVE_TYPE_LABEL: label_value})._value.get() == 0
+    assert (
+        w._processed_total.labels(**{ARCHIVE_TYPE_LABEL: label_value})._value.get() == 0
+    )
+    assert (
+        w._processed_timeout_total.labels(
+            **{ARCHIVE_TYPE_LABEL: label_value}
+        )._value.get()
+        == 0
+    )
+    assert (
+        w._published_total.labels(**{ARCHIVE_TYPE_LABEL: label_value})._value.get() == 0
+    )
+    assert (
+        w._failures_total.labels(**{ARCHIVE_TYPE_LABEL: label_value})._value.get() == 0
+    )
     assert w._not_handling_total._value.get() == 0
 
 
@@ -173,10 +223,21 @@ def test_stats_watcher_on_process(label_value):
     assert w._recv_total._value.get() == 0
     assert w._filtered_total._value.get() == 0
     assert w._downloaded_total._sum.get() == 0
-    assert w._processed_total.labels(**{ARCHIVE_TYPE_LABEL: label_value})._value.get() == 1
-    assert w._processed_timeout_total.labels(**{ARCHIVE_TYPE_LABEL: label_value})._value.get() == 0
-    assert w._published_total.labels(**{ARCHIVE_TYPE_LABEL: label_value})._value.get() == 0
-    assert w._failures_total.labels(**{ARCHIVE_TYPE_LABEL: label_value})._value.get() == 0
+    assert (
+        w._processed_total.labels(**{ARCHIVE_TYPE_LABEL: label_value})._value.get() == 1
+    )
+    assert (
+        w._processed_timeout_total.labels(
+            **{ARCHIVE_TYPE_LABEL: label_value}
+        )._value.get()
+        == 0
+    )
+    assert (
+        w._published_total.labels(**{ARCHIVE_TYPE_LABEL: label_value})._value.get() == 0
+    )
+    assert (
+        w._failures_total.labels(**{ARCHIVE_TYPE_LABEL: label_value})._value.get() == 0
+    )
     assert w._not_handling_total._value.get() == 0
 
 
@@ -195,10 +256,21 @@ def test_stats_watcher_on_process_timeout(label_value):
     assert w._recv_total._value.get() == 0
     assert w._filtered_total._value.get() == 0
     assert w._downloaded_total._sum.get() == 0
-    assert w._processed_total.labels(**{ARCHIVE_TYPE_LABEL: label_value})._value.get() == 0
-    assert w._processed_timeout_total.labels(**{ARCHIVE_TYPE_LABEL: label_value})._value.get() == 1
-    assert w._published_total.labels(**{ARCHIVE_TYPE_LABEL: label_value})._value.get() == 0
-    assert w._failures_total.labels(**{ARCHIVE_TYPE_LABEL: label_value})._value.get() == 0
+    assert (
+        w._processed_total.labels(**{ARCHIVE_TYPE_LABEL: label_value})._value.get() == 0
+    )
+    assert (
+        w._processed_timeout_total.labels(
+            **{ARCHIVE_TYPE_LABEL: label_value}
+        )._value.get()
+        == 1
+    )
+    assert (
+        w._published_total.labels(**{ARCHIVE_TYPE_LABEL: label_value})._value.get() == 0
+    )
+    assert (
+        w._failures_total.labels(**{ARCHIVE_TYPE_LABEL: label_value})._value.get() == 0
+    )
     assert w._not_handling_total._value.get() == 0
 
 
@@ -219,10 +291,21 @@ def test_stats_watcher_on_consumer_success(label_value):
     assert w._recv_total._value.get() == 0
     assert w._filtered_total._value.get() == 0
     assert w._downloaded_total._sum.get() == 0
-    assert w._processed_total.labels(**{ARCHIVE_TYPE_LABEL: label_value})._value.get() == 0
-    assert w._processed_timeout_total.labels(**{ARCHIVE_TYPE_LABEL: label_value})._value.get() == 0
-    assert w._published_total.labels(**{ARCHIVE_TYPE_LABEL: label_value})._value.get() == 1
-    assert w._failures_total.labels(**{ARCHIVE_TYPE_LABEL: label_value})._value.get() == 0
+    assert (
+        w._processed_total.labels(**{ARCHIVE_TYPE_LABEL: label_value})._value.get() == 0
+    )
+    assert (
+        w._processed_timeout_total.labels(
+            **{ARCHIVE_TYPE_LABEL: label_value}
+        )._value.get()
+        == 0
+    )
+    assert (
+        w._published_total.labels(**{ARCHIVE_TYPE_LABEL: label_value})._value.get() == 1
+    )
+    assert (
+        w._failures_total.labels(**{ARCHIVE_TYPE_LABEL: label_value})._value.get() == 0
+    )
     assert w._not_handling_total._value.get() == 0
 
 
@@ -243,10 +326,21 @@ def test_stats_watcher_on_consumer_failure(label_value):
     assert w._recv_total._value.get() == 0
     assert w._filtered_total._value.get() == 0
     assert w._downloaded_total._sum.get() == 0
-    assert w._processed_total.labels(**{ARCHIVE_TYPE_LABEL: label_value})._value.get() == 0
-    assert w._processed_timeout_total.labels(**{ARCHIVE_TYPE_LABEL: label_value})._value.get() == 0
-    assert w._published_total.labels(**{ARCHIVE_TYPE_LABEL: label_value})._value.get() == 0
-    assert w._failures_total.labels(**{ARCHIVE_TYPE_LABEL: label_value})._value.get() == 1
+    assert (
+        w._processed_total.labels(**{ARCHIVE_TYPE_LABEL: label_value})._value.get() == 0
+    )
+    assert (
+        w._processed_timeout_total.labels(
+            **{ARCHIVE_TYPE_LABEL: label_value}
+        )._value.get()
+        == 0
+    )
+    assert (
+        w._published_total.labels(**{ARCHIVE_TYPE_LABEL: label_value})._value.get() == 0
+    )
+    assert (
+        w._failures_total.labels(**{ARCHIVE_TYPE_LABEL: label_value})._value.get() == 1
+    )
     assert w._not_handling_total._value.get() == 0
 
     # reset downloaded time
@@ -256,7 +350,9 @@ def test_stats_watcher_on_consumer_failure(label_value):
     w.on_consumer_failure(input_msg, Exception("something"))
 
     # metric should change
-    assert w._failures_total.labels(**{ARCHIVE_TYPE_LABEL: label_value})._value.get() == 2
+    assert (
+        w._failures_total.labels(**{ARCHIVE_TYPE_LABEL: label_value})._value.get() == 2
+    )
 
     # reset processed time
     w._processed_time = None
@@ -265,7 +361,9 @@ def test_stats_watcher_on_consumer_failure(label_value):
     w.on_consumer_failure(input_msg, Exception("something"))
 
     # metric should change again
-    assert w._failures_total.labels(**{ARCHIVE_TYPE_LABEL: label_value})._value.get() == 3
+    assert (
+        w._failures_total.labels(**{ARCHIVE_TYPE_LABEL: label_value})._value.get() == 3
+    )
 
     # now try this - downloaded time is not None and processed time is none
     w._downloaded_time = time.time()
@@ -275,7 +373,9 @@ def test_stats_watcher_on_consumer_failure(label_value):
     w.on_consumer_failure(input_msg, Exception("something"))
 
     # metric should change again
-    assert w._failures_total.labels(**{ARCHIVE_TYPE_LABEL: label_value})._value.get() == 4
+    assert (
+        w._failures_total.labels(**{ARCHIVE_TYPE_LABEL: label_value})._value.get() == 4
+    )
 
 
 @patch("ccx_messaging.watchers.stats_watcher.start_http_server", lambda *args: None)
@@ -295,10 +395,21 @@ def test_stats_watcher_on_not_handled(label_value):
     assert w._recv_total._value.get() == 0
     assert w._filtered_total._value.get() == 0
     assert w._downloaded_total._sum.get() == 0
-    assert w._processed_total.labels(**{ARCHIVE_TYPE_LABEL: label_value})._value.get() == 0
-    assert w._processed_timeout_total.labels(**{ARCHIVE_TYPE_LABEL: label_value})._value.get() == 0
-    assert w._published_total.labels(**{ARCHIVE_TYPE_LABEL: label_value})._value.get() == 0
-    assert w._failures_total.labels(**{ARCHIVE_TYPE_LABEL: label_value})._value.get() == 0
+    assert (
+        w._processed_total.labels(**{ARCHIVE_TYPE_LABEL: label_value})._value.get() == 0
+    )
+    assert (
+        w._processed_timeout_total.labels(
+            **{ARCHIVE_TYPE_LABEL: label_value}
+        )._value.get()
+        == 0
+    )
+    assert (
+        w._published_total.labels(**{ARCHIVE_TYPE_LABEL: label_value})._value.get() == 0
+    )
+    assert (
+        w._failures_total.labels(**{ARCHIVE_TYPE_LABEL: label_value})._value.get() == 0
+    )
     assert w._not_handling_total._value.get() == 1
 
 
@@ -321,6 +432,7 @@ def test_reset_times():
     assert w._processed_time is None
     assert w._published_time is None
 
+
 @patch("ccx_messaging.watchers.stats_watcher.start_http_server", lambda *args: None)
 def test_reset_archive_type(label_value):
     """Test the method _reset_times()."""
@@ -330,4 +442,4 @@ def test_reset_archive_type(label_value):
 
     w._reset_archive_type()
 
-    assert w._archive_type is 'ocp'
+    assert w._archive_type == "ocp"


### PR DESCRIPTION
# Description

The "archive" label allows us to differentiate the type of archive we are handling. Since that information is known only after extracting the archive, the following changes have been implemented:

  - "archive" label was added to StatsWatcher
  - The new label is only used in metrics that are updated after the extraction of the archive:
    - ccx_consumer_extracted_total
    - ccx_engine_processed_total
    - ccx_published_total
    - ccx_failures_total
    - ccx_process_duration_seconds if there was a failure during download or processing of the archive
    - ccx_publish_duration_seconds
    - ccx_engine_processed_timeout_total
  - The label's value is reset to 'ocp' everytime a new archive is received (when `on_recv` is fired).

Fixes CCXDEV-12520

## Type of change

- New feature (non-breaking change which adds functionality)

## Testing steps

Updated UTs

## Checklist
* [x] `pre-commit run -a` passes
* [ ] updated documentation wherever necessary
* [x] added or modified tests if necessary
* [ ] updated schemas and validators in [insights-data-schemas](https://github.com/RedHatInsights/insights-data-schemas) in case of input/output change
