### PR TITLE
Adding ACL permissions to every uploaded archive

### DIFF
--- a/ccx_messaging/utils/s3_uploader.py
+++ b/ccx_messaging/utils/s3_uploader.py
@@ -24,20 +24,13 @@ LOG = logging.getLogger(__name__)
 class S3Uploader:
     """S3 uploader."""
 
-    def __init__(self, **kwargs):
+    def __init__(self, access_key, secret_key, endpoint):
         """Inicialize uploader."""
-        access_key = kwargs.get("access_key", None)
-        secret_key = kwargs.get("secret_key", None)
-        endpoint = kwargs.get("endpoint", None)
-
         if not access_key:
-            raise Exception("Access Key environment variable not set.")
+            raise TypeError("access_key cannot be nulleable")
 
         if not secret_key:
-            raise Exception("Secret Key environment variable not set.")
-
-        if not endpoint:
-            raise Exception("Endpoint environment variable not set.")
+            raise TypeError("secret_key cannot be nulleable")
 
         session = boto3.session.Session()
 
@@ -53,5 +46,7 @@ class S3Uploader:
         LOG.info(f"Uploading '{file_name}' as '{path}' to '{bucket}'")
 
         with open(path, "rb") as file_data:
-            self.client.put_object(Bucket=bucket, Key=file_name, Body=file_data)
+            self.client.put_object(
+                Bucket=bucket, Key=file_name, Body=file_data, ACL="bucket-owner-read"
+            )
             LOG.info(f"Uploaded '{file_name}' as '{path}' to '{bucket}'")

--- a/test/engines/s3_uploader_engine_test.py
+++ b/test/engines/s3_uploader_engine_test.py
@@ -63,7 +63,7 @@ def test_init():
 
 def test_bad_key():
     """Test inicialization of engine with bad key."""
-    with pytest.raises(Exception):
+    with pytest.raises(TypeError):
         S3UploadEngine(
             None,
             access_key="",


### PR DESCRIPTION
# Description

Make the S3 uploader, by default, to allow the bucket owner to access the uploaded files. By default, in ACL-configured buckets, the ACL doesn't allow the owner of the bucket to read the objects.

## Type of change

- Refactor (refactoring code, removing useless files)

## Testing steps

Added some unit tests. Tested locally

## Checklist
* [x] `pre-commit run -a` passes
* [ ] updated documentation wherever necessary
* [x] added or modified tests if necessary
* [-] updated schemas and validators in [insights-data-schemas](https://github.com/RedHatInsights/insights-data-schemas) in case of input/output change
