### PR TITLE
Fix-on-fix error in return type for OCP Engine

### DIFF
--- a/ccx_messaging/engines/ocp_engine.py
+++ b/ccx_messaging/engines/ocp_engine.py
@@ -61,7 +61,7 @@ class OCPEngine(ICMEngine):
                 ols_file = os.path.join(extraction.tmp_dir, "openshift_lightspeed.json")
                 if os.path.exists(ols_file):
                     log.debug("archive contains openshift_lightspeed.json file; skipping")
-                    return {}
+                    return "{}"
 
                 output = StringIO()
                 with self.Formatter(broker, stream=output):

--- a/test/engines/ocp_engine_test.py
+++ b/test/engines/ocp_engine_test.py
@@ -77,4 +77,4 @@ def test_process_extract_ols_archive():
     path = "test/ols.tar"
 
     result = e.process(broker, path)
-    assert result == {}
+    assert result == "{}"


### PR DESCRIPTION
# Description

The previous fix was wrong, as the returned value should be an string or bytes-like objects containing a serialized JSON

## Type of change

- Bug fix (non-breaking change which fixes an issue)

## Testing steps

Tested locally with unit tests and small manual integration test

## Checklist
* [x] `pre-commit run -a` passes
* [ ] updated documentation wherever necessary
* [ ] added or modified tests if necessary
* [ ] updated schemas and validators in [insights-data-schemas](https://github.com/RedHatInsights/insights-data-schemas) in case of input/output change
