### PR TITLE
Revert "Update pr_check.sh to deploy the archive-sync on ephemeral"

### DIFF
--- a/pr_check.sh
+++ b/pr_check.sh
@@ -4,21 +4,6 @@ CICD_TOOLS_URL="https://raw.githubusercontent.com/RedHatInsights/cicd-tools/main
 export CICD_IMAGE_BUILDER_IMAGE_NAME='quay.io/cloudservices/ccx-messaging'
 export CICD_IMAGE_BUILDER_ADDITIONAL_TAGS=("latest")
 
-APP_NAME="ccx-data-pipeline"  # name of app-sre "application" folder this component lives in
-COMPONENT_NAME="archive-sync"  # name of app-sre "resourceTemplate" in deploy.yaml for this component
-IMAGE="quay.io/cloudservices/ccx-messaging"
-COMPONENTS="archive-sync"  # space-separated list of components to load
-COMPONENTS_W_RESOURCES="archive-sync"  # component to keep
-CACHE_FROM_LATEST_IMAGE="true"
-
-export IQE_PLUGINS="ccx"
-export IQE_MARKER_EXPRESSION=""
-# Workaround: There are no specific integration tests. Check that the service loads and iqe plugin works.
-export IQE_FILTER_EXPRESSION="test_plugin_accessible"
-export IQE_REQUIREMENTS_PRIORITY=""
-export IQE_TEST_IMPORTANCE=""
-export IQE_CJI_TIMEOUT="30m"
-
 # shellcheck source=/dev/null
 if ! source <(curl -sSL "$CICD_TOOLS_URL") image_builder; then
     echo "Error loading image_builder module!"
@@ -27,18 +12,6 @@ fi
 
 if ! cicd::image_builder::build_and_push; then
     echo "Error building image!"
-    exit 1
-fi
-CICD_TOOLS_BOOTSTRAP_SCRIPT="https://raw.githubusercontent.com/RedHatInsights/cicd-tools/main/bootstrap.sh"
-
-# shellcheck source=/dev/null
-if ! source <(curl -sSL "$CICD_TOOLS_BOOTSTRAP_SCRIPT") ; then
-    echo "Error loading bootstrap script!"
-    exit 1
-fi
-# Try to deploy the service on ephemeral to check the changes haven't break it
-if ! source $CICD_ROOT/deploy_ephemeral_env.sh; then
-    echo "Error deploying the service on ephemeral!"
     exit 1
 fi
 


### PR DESCRIPTION
Reverts RedHatInsights/insights-ccx-messaging#215


The `archive-sync` component doesn't exist, and there's no service we deploy directly using ccx-messaging right now.