### PR TITLE
[CCXDEV-14176] GH actions: fix precommit install issue

### DIFF
--- a/.github/workflows/linters.yml
+++ b/.github/workflows/linters.yml
@@ -15,6 +15,8 @@ jobs:
     steps:
       - uses: actions/checkout@v4
       - uses: actions/setup-python@v5
+        with:
+            python-version: '3.12'
       - uses: pre-commit/action@v3.0.1
         with:
           extra_args: flake8 --all-files
@@ -24,6 +26,8 @@ jobs:
       steps:
         - uses: actions/checkout@v4
         - uses: actions/setup-python@v5
+          with:
+              python-version: '3.12'
         - uses: pre-commit/action@v3.0.1
           with:
             extra_args: pyupgrade --all-files
@@ -33,6 +37,8 @@ jobs:
       steps:
         - uses: actions/checkout@v4
         - uses: actions/setup-python@v5
+          with:
+              python-version: '3.12'
         - uses: pre-commit/action@v3.0.1
           with:
             extra_args: pydocstyle --all-files


### PR DESCRIPTION
# Description

[CCXDEV-14176] GH actions: fix precommit install issue

```
Run pre-commit/action@v3.0.1
Run python -m pip install pre-commit
error: externally-managed-environment

× This environment is externally managed
╰─> To install Python packages system-wide, try apt install
    python3-xyz, where xyz is the package you are trying to
    install.
    
    If you wish to install a non-Debian-packaged Python package,
    create a virtual environment using python3 -m venv path/to/venv.
    Then use path/to/venv/bin/python and path/to/venv/bin/pip. Make
    sure you have python3-full installed.
    
    If you wish to install a non-Debian packaged Python application,
    it may be easiest to use pipx install xyz, which will manage a
    virtual environment for you. Make sure you have pipx installed.
    
    See /usr/share/doc/python3.12/README.venv for more information.

note: If you believe this is a mistake, please contact your Python installation or OS distribution provider. You can override this, at the risk of breaking your Python installation or OS, by passing --break-system-packages.
hint: See PEP 668 for the detailed specification.
```

## Type of change

- Configuration update