### PR TITLE
Install missing dependency

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -5,7 +5,7 @@ insights-core>=3.1.2
 insights-core-messaging @ git+https://github.com/RedHatInsights/insights-core-messaging@1.2.10
 jsonschema>=4.0.0
 prometheus-client>=0.16.0
-python-json-logger>=2.0.7
+python-json-logger>=2.0.7,<3
 PyYAML>=6.0
 requests>=2.31.0
 sentry-sdk>=1.37.1

--- a/requirements.txt
+++ b/requirements.txt
@@ -3,9 +3,10 @@ boto3>=1.34.1,<1.35.77
 confluent-kafka>=2.0.0
 insights-core>=3.1.2
 insights-core-messaging @ git+https://github.com/RedHatInsights/insights-core-messaging@1.2.10
+msgspec>=0.18.5
 jsonschema>=4.0.0
 prometheus-client>=0.16.0
-python-json-logger>=2.0.7,<3
+python-json-logger>=2.0.7
 PyYAML>=6.0
 requests>=2.31.0
 sentry-sdk>=1.37.1


### PR DESCRIPTION
python-json-logger has stopped included the dependency although needed by our logging configuration.

See https://github.com/nhairs/python-json-logger/issues/30

## Type of change

- Bump-up dependent library (no changes in the code)

## Checklist
* [ ] `pre-commit run -a` passes
* [ ] updated documentation wherever necessary
* [ ] added or modified tests if necessary
* [ ] updated schemas and validators in [insights-data-schemas](https://github.com/RedHatInsights/insights-data-schemas) in case of input/output change
