### PR TITLE
Remove initializer for OCPEngine

### DIFF
--- a/ccx_messaging/engines/ocp_engine.py
+++ b/ccx_messaging/engines/ocp_engine.py
@@ -29,16 +29,6 @@ log = logging.getLogger(__name__)
 class OCPEngine(ICMEngine):
     """Extract, download and process IO archive."""
 
-    def __init__(
-        self,
-        formatter,
-        target_components=None,
-        extract_timeout=None,
-        extract_tmp_dir=None,
-    ):
-        """`Engine` initializer."""
-        super().__init__(formatter, target_components, extract_timeout, extract_tmp_dir)
-
     def process(self, broker, path):
         """Get results from applying Insights rules to the downloaded archive.
 


### PR DESCRIPTION
# Description

The initializer for OCPEngine class is not needed, as it only calls to its parent initializer. It was causing some problems when using newer versions of ICM and configuring this engine.

## Type of change

- Bug fix (non-breaking change which fixes an issue)

## Testing steps

Tested locally

## Checklist
* [ ] `pre-commit run -a` passes
* [ ] updated documentation wherever necessary
* [ ] added or modified tests if necessary
* [ ] updated schemas and validators in [insights-data-schemas](https://github.com/RedHatInsights/insights-data-schemas) in case of input/output change
