### PR TITLE
Cleanup linters and CI tools

### DIFF
--- a/.github/workflows/linters.yml
+++ b/.github/workflows/linters.yml
@@ -4,41 +4,23 @@ on:
   - pull_request
 
 jobs:
-  ruff:
+  pre-commit-hooks:
     runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v4
-      - uses: chartboost/ruff-action@v1
+    strategy:
+      matrix:
+        hook_id:
+          - "trailing-whitespace"
+          - "end-of-file-fixer"
+          - "check-yaml"
+          - "debug-statements"
+          - "ruff"
+          - "pyupgrade"
 
-  pre-commit-flake8:
-    runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
       - uses: actions/setup-python@v5
         with:
-            python-version: '3.12'
+          python-version: '3.12'
       - uses: pre-commit/action@v3.0.1
         with:
-          extra_args: flake8 --all-files
-
-  pre-commit-pyupgrade:
-      runs-on: ubuntu-latest
-      steps:
-        - uses: actions/checkout@v4
-        - uses: actions/setup-python@v5
-          with:
-              python-version: '3.12'
-        - uses: pre-commit/action@v3.0.1
-          with:
-            extra_args: pyupgrade --all-files
-
-  pre-commit-pydocstyle:
-      runs-on: ubuntu-latest
-      steps:
-        - uses: actions/checkout@v4
-        - uses: actions/setup-python@v5
-          with:
-              python-version: '3.12'
-        - uses: pre-commit/action@v3.0.1
-          with:
-            extra_args: pydocstyle --all-files
+          extra_args: ${{ matrix.hook_id }} --all-files

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,12 +1,5 @@
 exclude: "doc|research|demos"
 repos:
-- repo: https://github.com/psf/black
-  rev: 24.10.0
-  hooks:
-  - id: black
-    args: [--safe, --quiet, --line-length, "100"]
-    language_version: python3
-    require_serial: true
 - repo: https://github.com/pre-commit/pre-commit-hooks
   rev: v5.0.0
   hooks:
@@ -18,19 +11,15 @@ repos:
     language_version: python3
   - id: debug-statements
     language_version: python3
+
+- repo: https://github.com/astral-sh/ruff-pre-commit
+  rev: v0.9.0
+  hooks:
+    - id: ruff
+    # - id: ruff-format
+
 - repo: https://github.com/asottile/pyupgrade
   rev: v3.19.1
   hooks:
   - id: pyupgrade
     language_version: python3
-- repo: https://github.com/PyCQA/flake8
-  rev: 7.1.1
-  hooks:
-    - id: flake8
-      language_version: python3
-      args: [--extend-ignore=E501,--extend-ignore=E203]
-- repo: https://gitlab.com/pycqa/pydocstyle
-  rev: 6.1.1
-  hooks:
-    - id: pydocstyle
-      language_version: python3

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -51,23 +51,22 @@ Homepage = "https://github.com/RedHatInsights/insights-ccx-messaging"
 ccx-messaging = "ccx_messaging.command_line:ccx_messaging"
 
 [project.optional-dependencies]
-dev = [
-    "black",
-    "coverage",
-    "flake8",
-    "freezegun",
-    "pycco",
-    "pycodestyle",
-    "pydocstyle",
-    "pylint",
+test = [
     "pytest",
     "pytest-cov",
+    "freezegun"
+]
+dev = [
+    "coverage",
+    "pycco",
     "ruff"
 ]
 
 [tool.setuptools_scm]
 
 [tool.ruff]
+line-length = 100
+
+[tool.ruff.lint]
 select = ["E", "F", "W", "UP", "C", "D"]
 ignore = ["D211", "C401", "D203", "D213", "UP006", "UP007", "UP009", "UP015", "UP035"]
-line-length = 100

--- a/tox.ini
+++ b/tox.ini
@@ -6,17 +6,10 @@ envlist = py{311,312}
 usedevelop = True
 deps = -r requirements.txt
 install_command = pip install {opts} {packages}
-extras = dev
+extras = test
 commands =
     pytest -v --cov=ccx_messaging --cov-fail-under=70
     pytest -v --cov=ccx_messaging --cov-report=xml
-
-[pycodestyle]
-max-line-length = 100
-
-[flake8]
-extend-ignore = E203
-max-line-length = 100
 
 [gh]
 python =


### PR DESCRIPTION
# Description

- black was not used for ages in CI, ruff can be used for formatting too
- flake8 is overseeded by ruff
- pydocstyle was deprecated in favour of ruff, that we are already using.
- Creating a new category of optional deps for testing
- Fix ruff configuration warning
- Adding ruff to pre-commit, just check

## Type of change

- CI configuration

## Testing steps

Tested locally with pre-commit

## Checklist
* [X] `pre-commit run -a` passes
* [ ] updated documentation wherever necessary
* [ ] added or modified tests if necessary
* [ ] updated schemas and validators in [insights-data-schemas](https://github.com/RedHatInsights/insights-data-schemas) in case of input/output change
