### PR TITLE
Draft: Make ACL during archive upload optional

### DIFF
--- a/ccx_messaging/engines/s3_upload_engine.py
+++ b/ccx_messaging/engines/s3_upload_engine.py
@@ -55,6 +55,7 @@ class S3UploadEngine(Engine):
         endpoint=None,
         archives_path_prefix=None,
         archive_name_pattern="$cluster_id[:2]/$cluster_id/$year$month/$day/$time.tar.gz",
+        s3_acl_enabled=True,
     ):
         """Initialize engine for S3 upload.
 
@@ -73,6 +74,8 @@ class S3UploadEngine(Engine):
             archive path or other availables timestamps.
           - `archive`: it will be replaced by the base name of the archive.
         """
+        LOG.debug(type(s3_acl_enabled))
+        LOG.debug(s3_acl_enabled)
         super().__init__(
             formatter=formatter,
             target_components=target_components,
@@ -83,10 +86,13 @@ class S3UploadEngine(Engine):
         self.dest_bucket = dest_bucket
         self.archives_path_prefix = archives_path_prefix
         self.archive_name_template = SlicedTemplate(archive_name_pattern)
+        if isinstance(s3_acl_enabled, str):
+            s3_acl_enabled = s3_acl_enabled.lower() == "true"
         self.uploader = S3Uploader(
             access_key=access_key,
             secret_key=secret_key,
             endpoint=endpoint,
+            acl_enabled=s3_acl_enabled,
         )
 
     def process(self, broker, local_path):

--- a/ccx_messaging/utils/s3_uploader.py
+++ b/ccx_messaging/utils/s3_uploader.py
@@ -24,7 +24,7 @@ LOG = logging.getLogger(__name__)
 class S3Uploader:
     """S3 uploader."""
 
-    def __init__(self, access_key, secret_key, endpoint):
+    def __init__(self, access_key, secret_key, endpoint, acl_enabled=True):
         """Inicialize uploader."""
         if not access_key:
             raise TypeError("access_key cannot be nulleable")
@@ -41,12 +41,19 @@ class S3Uploader:
             endpoint_url=endpoint,
         )
 
+        self.acl_enabled = acl_enabled
+
     def upload_file(self, path, bucket, file_name):
         """Upload file to target path in bucket."""
         LOG.info(f"Uploading '{file_name}' as '{path}' to '{bucket}'")
 
         with open(path, "rb") as file_data:
-            self.client.put_object(
-                Bucket=bucket, Key=file_name, Body=file_data, ACL="bucket-owner-read"
-            )
+            if self.acl_enabled:
+                self.client.put_object(
+                    Bucket=bucket, Key=file_name, Body=file_data, ACL="bucket-owner-read"
+                )
+            else:
+                self.client.put_object(
+                    Bucket=bucket, Key=file_name, Body=file_data
+                )
             LOG.info(f"Uploaded '{file_name}' as '{path}' to '{bucket}'")


### PR DESCRIPTION
# Description

Our AWS S3 buckets do not allow setting ACLs, so we are making that optional.


## Type of change

- New feature (non-breaking change which adds functionality)

## Testing steps

NA

## Checklist
* [ ] `pre-commit run -a` passes
* [ ] updated documentation wherever necessary
* [ ] added or modified tests if necessary
* [ ] updated schemas and validators in [insights-data-schemas](https://github.com/RedHatInsights/insights-data-schemas) in case of input/output change
