### PR TITLE
Update boto3 requirement from <1.36.3,>=1.34.1 to >=1.34.1,<1.36.4

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -25,7 +25,7 @@ classifiers = [
 requires-python = ">= 3.8"
 dependencies = [
     "app-common-python>=0.2.3",
-    "boto3>=1.34.1,<1.36.3",  # limited due to incompatibility between s3fs and newer versions of boto
+    "boto3>=1.34.1,<1.36.4",  # limited due to incompatibility between s3fs and newer versions of boto
     "confluent-kafka>=2.0.0",
     "insights-core>=3.1.2",
     "insights-core-messaging>=1.2.15",

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,5 @@
 app-common-python>=0.2.3
-boto3>=1.34.1,<1.36.3
+boto3>=1.34.1,<1.36.4
 confluent-kafka>=2.0.0
 insights-core>=3.1.2
 insights-core-messaging @ git+https://github.com/RedHatInsights/insights-core-messaging@1.2.17


### PR DESCRIPTION
# Description

In order to update as much as possible boto3 dependencies, I created this bump by hand:

Context:
ccx-messaging depends on ICM and boto3.
ICM depends on s3fs.
s3fs depends on aiobotocore
aiobotocore [depends on botocore <= 1.36.4](https://github.com/aio-libs/aiobotocore/blob/af434cdefdac6f8a6f1b38b5234554a6f44c8ba2/pyproject.toml#L35)

So, we are restricted to the same version as aiobotocore because the transitive dependencies.

## Type of change
- Bump-up dependent library (no changes in the code)

## Testing steps

Built imag locally and checked dependencies.

## Checklist
* [x] `pre-commit run -a` passes
* [ ] updated documentation wherever necessary
* [ ] added or modified tests if necessary
* [ ] updated schemas and validators in [insights-data-schemas](https://github.com/RedHatInsights/insights-data-schemas) in case of input/output change
