### PR TITLE
[CCXDEV-14812] Processing time control variable never assigned

### DIFF
--- a/ccx_messaging/consumers/kafka_consumer.py
+++ b/ccx_messaging/consumers/kafka_consumer.py
@@ -177,6 +177,7 @@ class KafkaConsumer(Consumer):
             LOG.debug("Empty record. Should not happen")
             return
 
+        self.last_received_message_time = time.time()
         if msg.error():
             raise KafkaException(msg.error())
 

--- a/ccx_messaging/consumers/synced_archive_consumer.py
+++ b/ccx_messaging/consumers/synced_archive_consumer.py
@@ -1,6 +1,7 @@
 """Module containing the consumer for the Kafka topic produced by the Archive Sync service."""
 
 import logging
+import time
 from typing import Any
 
 from confluent_kafka import Message, KafkaException
@@ -29,6 +30,7 @@ class SyncedArchiveConsumer(KafkaConsumer):
             LOG.debug("Empty record. Should not happen")
             return
 
+        self.last_received_message_time = time.time()  # Base class thread control
         if msg.error():
             raise KafkaException(msg.error())
 

--- a/test/consumers/idp_kafka_consumer_test.py
+++ b/test/consumers/idp_kafka_consumer_test.py
@@ -14,9 +14,11 @@
 
 """Module containing unit tests for the `KafkaConsumer` class."""
 
+import datetime
 from unittest.mock import MagicMock, patch
 
 import pytest
+from freezegun import freeze_time
 
 from ccx_messaging.consumers.idp_kafka_consumer import IDPConsumer
 from ccx_messaging.error import CCXMessagingError
@@ -271,3 +273,26 @@ def test_create_broker_bad_cluster_id_short():
     sut = IDPConsumer(None, None, None, incoming_topic=None)
     with pytest.raises(CCXMessagingError):
         sut.create_broker(input_msg)
+
+
+@patch("ccx_messaging.consumers.kafka_consumer.ConfluentConsumer", lambda *a, **k: MagicMock())
+@patch("ccx_messaging.consumers.kafka_consumer.KafkaConsumer.handles", lambda *a, **k: True)
+@patch("ccx_messaging.consumers.kafka_consumer.KafkaConsumer.fire", lambda *a, **k: None)
+def test_last_received_message_time_is_updated():
+    """Check that the variable last_received_message_time used by a Thread is correctly updated.
+
+    [CCXDEV-14812] the variable is never updated
+    """
+    t1 = datetime.datetime(2025, 1, 31, 12, 0, 0, tzinfo=datetime.timezone.utc)
+    t2 = datetime.datetime(2025, 1, 31, 12, 20, 0, tzinfo=datetime.timezone.utc)
+
+    with freeze_time(t1) as frozen_time:
+        sut = IDPConsumer(None, None, None, incoming_topic=None)
+        input_msg = KafkaMessage("{}")
+
+        frozen_time.move_to(t2)
+
+        with patch("ccx_messaging.consumers.kafka_consumer.KafkaConsumer.process", lambda: None):
+            sut.process_msg(input_msg)
+
+        assert sut.last_received_message_time == t2.timestamp()


### PR DESCRIPTION
# Description

The `KafkaConsumer` class (used directly or as a superclass for other Kafka based consumers) defines a thread that checks every hour if the consumer is still receiving and processing archives.

The problem was that the variable controlling the last processed archive time was never updated, so it is always reporting "no new messages in queue", even if we are processing.

Fixes #[CCXDEV-14812](https://issues.redhat.com/browse/CCXDEV-14812)

## Type of change

- Bug fix (non-breaking change which fixes an issue)
- Unit tests (no changes in the code)

## Testing steps

Added new tests to reproduce the problem locally.

## Checklist
* [X] `pre-commit run -a` passes
* [ ] updated documentation wherever necessary
* [X] added or modified tests if necessary
* [ ] updated schemas and validators in [insights-data-schemas](https://github.com/RedHatInsights/insights-data-schemas) in case of input/output change
