### PR TITLE
[CCXDEV-14813] Handling InvalidContentType correctly

### DIFF
--- a/ccx_messaging/consumers/kafka_consumer.py
+++ b/ccx_messaging/consumers/kafka_consumer.py
@@ -13,6 +13,7 @@ from confluent_kafka import (
     TIMESTAMP_NOT_AVAILABLE,
 )
 from insights import dr
+from insights.core.exceptions import InvalidContentType
 from insights_messaging.consumers import Consumer
 
 from ccx_messaging.error import CCXMessagingError
@@ -196,6 +197,10 @@ class KafkaConsumer(Consumer):
 
             # Core Messaging process
             self.process(value)
+
+        except InvalidContentType as ex:
+            LOG.warning("The archive cannot be processed by Insights: %s", ex)
+            self.process_dead_letter(msg)
 
         except CCXMessagingError as ex:
             LOG.warning(

--- a/ccx_messaging/consumers/synced_archive_consumer.py
+++ b/ccx_messaging/consumers/synced_archive_consumer.py
@@ -6,6 +6,7 @@ from typing import Any
 
 from confluent_kafka import Message, KafkaException
 from insights import dr
+from insights.core.exceptions import InvalidContentType
 from insights_messaging.consumers import Consumer
 
 from ccx_messaging.consumers.kafka_consumer import KafkaConsumer
@@ -39,6 +40,10 @@ class SyncedArchiveConsumer(KafkaConsumer):
             value = self.deserialize(msg)
             # Core Messaging process
             self.process(value)
+
+        except InvalidContentType as ex:
+            LOG.warning("The archive cannot be processed by Insights: %s", ex)
+            self.process_dead_letter(msg)
 
         except CCXMessagingError as ex:
             LOG.warning(


### PR DESCRIPTION
# Description

Some archives can be malformed, so Insights raises the `InvalidContentType` exception. On that situation, the library is handling it with the most generic exception handler, which emits a logging ERROR. Depending on the configuration, it can create Sentry notifications that we want to avoid, as there is nothing that our service can do to avoid this type of error.

Fixes #[CCXDEV-14813](https://issues.redhat.com/browse/CCXDEV-14813)

## Type of change

- Bug fix (non-breaking change which fixes an issue)

## Testing steps

N/A

## Checklist
* [X] `pre-commit run -a` passes
* [ ] updated documentation wherever necessary
* [ ] added or modified tests if necessary
* [ ] updated schemas and validators in [insights-data-schemas](https://github.com/RedHatInsights/insights-data-schemas) in case of input/output change
