### PR TITLE
[CCXDEV-14814] Handle archives without remote configuration version

### DIFF
--- a/ccx_messaging/watchers/stats_watcher.py
+++ b/ccx_messaging/watchers/stats_watcher.py
@@ -125,7 +125,7 @@ class StatsWatcher(ConsumerWatcher, EngineWatcher):
         # Archive type used in the metrics is set within on_extract, as we need
         # to extract the archive in order to know that information
         # TODO: Change to archive metadata dict, with archive type and archive size
-        self._archive_metadata = {"type": "ocp", "size": 0}
+        self._archive_metadata = {"type": "ocp", "size": 0, "s3_path": ""}
 
         self._initialize_metrics_with_labels()
 
@@ -152,6 +152,7 @@ class StatsWatcher(ConsumerWatcher, EngineWatcher):
         """On extract event handler for extractor using engines."""
         LOG.debug("Receiving 'on_extract' callback")
 
+        self._archive_metadata["s3_path"] = broker["original_path"]
         if isinstance(extraction, tarfile.TarFile):
             self.on_extract_with_tarfile(extraction)
 
@@ -192,6 +193,12 @@ class StatsWatcher(ConsumerWatcher, EngineWatcher):
                 self._gathering_conditions_remote_configuration_version.labels(version).inc()
         except FileNotFoundError:
             LOG.debug("this archive didn't use remote-configurations")
+        except KeyError:
+            LOG.warn(
+                f"archive {self._archive_metadata['s3_path']} doesn't have "
+                "a version in the remote-configuration"
+            )
+            self._gathering_conditions_remote_configuration_version.labels("None").inc()
         except Exception as e:
             LOG.error("cannot read remote-configuration.json", exc_info=e)
 
@@ -267,6 +274,7 @@ class StatsWatcher(ConsumerWatcher, EngineWatcher):
         """Reset the cached archive metadata."""
         self._archive_metadata["type"] = "ocp"
         self._archive_metadata["size"] = 0
+        self._archive_metadata["s3_path"] = ""
 
     def _initialize_metrics_with_labels(self):
         """Initialize Prometheus metrics that have at least one label.

--- a/ccx_messaging/watchers/stats_watcher.py
+++ b/ccx_messaging/watchers/stats_watcher.py
@@ -140,6 +140,8 @@ class StatsWatcher(ConsumerWatcher, EngineWatcher):
         self._start_time = time.time()
         self._reset_times()
         self._reset_archive_metadata()
+        
+        self._archive_metadata["s3_path"] = input_msg["path"]
 
     def on_filter(self):
         """On filter event handler."""
@@ -152,7 +154,6 @@ class StatsWatcher(ConsumerWatcher, EngineWatcher):
         """On extract event handler for extractor using engines."""
         LOG.debug("Receiving 'on_extract' callback")
 
-        self._archive_metadata["s3_path"] = broker["original_path"]
         if isinstance(extraction, tarfile.TarFile):
             self.on_extract_with_tarfile(extraction)
 

--- a/ccx_messaging/watchers/stats_watcher.py
+++ b/ccx_messaging/watchers/stats_watcher.py
@@ -140,7 +140,7 @@ class StatsWatcher(ConsumerWatcher, EngineWatcher):
         self._start_time = time.time()
         self._reset_times()
         self._reset_archive_metadata()
-        
+
         if "path" in input_msg:
             self._archive_metadata["s3_path"] = input_msg["path"]
         elif "url" in input_msg:

--- a/ccx_messaging/watchers/stats_watcher.py
+++ b/ccx_messaging/watchers/stats_watcher.py
@@ -141,7 +141,12 @@ class StatsWatcher(ConsumerWatcher, EngineWatcher):
         self._reset_times()
         self._reset_archive_metadata()
         
-        self._archive_metadata["s3_path"] = input_msg["path"]
+        if "path" in input_msg:
+            self._archive_metadata["s3_path"] = input_msg["path"]
+        elif "url" in input_msg:
+            self._archive_metadata["s3_path"] = input_msg["url"]
+        else:
+            LOG.error(f"message has no S3 path: {input_msg}")
 
     def on_filter(self):
         """On filter event handler."""

--- a/ccx_messaging/watchers/stats_watcher.py
+++ b/ccx_messaging/watchers/stats_watcher.py
@@ -200,7 +200,7 @@ class StatsWatcher(ConsumerWatcher, EngineWatcher):
         except FileNotFoundError:
             LOG.debug("this archive didn't use remote-configurations")
         except KeyError:
-            LOG.warn(
+            LOG.warning(
                 f"archive {self._archive_metadata['s3_path']} doesn't have "
                 "a version in the remote-configuration"
             )


### PR DESCRIPTION
# Description

Right now if an archive doesn't have a version in the remote-configuration file, it prints a general exception. Let's change that behaviour so that we have a warning with the archive path (for further investigation) and increase the metric of exposed version with a `None` value.

## Type of change

- Bug fix (non-breaking change which fixes an issue)

## Testing steps

CI.

## Checklist
* [x] `pre-commit run -a` passes
* [ ] updated documentation wherever necessary
* [ ] added or modified tests if necessary
* [ ] updated schemas and validators in [insights-data-schemas](https://github.com/RedHatInsights/insights-data-schemas) in case of input/output change
