### PR TITLE
[CCXDEV-14814] Prevent credentials leak

### DIFF
--- a/ccx_messaging/watchers/stats_watcher.py
+++ b/ccx_messaging/watchers/stats_watcher.py
@@ -144,7 +144,10 @@ class StatsWatcher(ConsumerWatcher, EngineWatcher):
         if "path" in input_msg:
             self._archive_metadata["s3_path"] = input_msg["path"]
         elif "url" in input_msg:
-            self._archive_metadata["s3_path"] = input_msg["url"]
+            # this means we are consuming directly from ingress (external
+            # pipeline), so printing the URL would include some short-live
+            # credentials used to access the archive. It's a risk to log this
+            pass
         else:
             LOG.error(f"message has no S3 path: {input_msg}")
 


### PR DESCRIPTION
# Description

Using the `input_msg["url"]` leaks some short-live AWS credentials to access the files. It's enough to log the buggy archives on the internal data pipeline.

## Type of change

- Bug fix (non-breaking change which fixes an issue)

## Testing steps

## Checklist
* [x] `pre-commit run -a` passes
* [ ] updated documentation wherever necessary
* [ ] added or modified tests if necessary
* [ ] updated schemas and validators in [insights-data-schemas](https://github.com/RedHatInsights/insights-data-schemas) in case of input/output change
