### PR TITLE
Print OCP version correctly at start up and during processing

### DIFF
--- a/ccx_messaging/command_line.py
+++ b/ccx_messaging/command_line.py
@@ -36,6 +36,12 @@ def print_version() -> None:
         sys.argv[0],
         importlib.metadata.version("ccx-messaging"),
     )
+    try:
+        ocp_rules_version = importlib.metadata.version("ccx-rules-ocp")
+        logger.info("ccx-rules-ocp version: %s", ocp_rules_version)
+
+    except importlib.metadata.PackageNotFoundError:
+        pass
 
 
 def apply_config(config) -> int:

--- a/ccx_messaging/consumers/kafka_consumer.py
+++ b/ccx_messaging/consumers/kafka_consumer.py
@@ -1,7 +1,7 @@
 """Kafka consumer implementation using Confluent Kafka library."""
 
+import importlib.metadata
 import logging
-import pkg_resources
 import time
 from datetime import datetime
 from threading import Thread
@@ -96,9 +96,9 @@ class KafkaConsumer(Consumer):
             self.dlq_producer = Producer(kafka_producer_config_cleanup(kwargs))
 
         try:
-            self.ocp_rules_version = pkg_resources.get_distribution("ccx_rules_ocp").version
+            self.ocp_rules_version = importlib.metadata.version("ccx-rules-ocp")
 
-        except pkg_resources.DistributionNotFound:
+        except importlib.metadata.PackageNotFoundError:
             logging.info("No OCP rules package is installed.")
             self.ocp_rules_version = None
 

--- a/ccx_messaging/consumers/synced_archive_consumer.py
+++ b/ccx_messaging/consumers/synced_archive_consumer.py
@@ -38,6 +38,10 @@ class SyncedArchiveConsumer(KafkaConsumer):
         try:
             # Deserialize
             value = self.deserialize(msg)
+
+            if self.ocp_rules_version:
+                LOG.info("Processing message using OCP rules version %s", self.ocp_rules_version)
+
             # Core Messaging process
             self.process(value)
 


### PR DESCRIPTION
# Description

Printing the OCP version at startup, if available, and during processing in the Kafka consumers related to rules processing.

Fixes #[CCXDEV-14859](https://issues.redhat.com/browse/CCXDEV-14859)

## Type of change

- Bug fix (non-breaking change which fixes an issue)

## Testing steps

Just pre-commit and minor local testing

## Checklist
* [x] `pre-commit run -a` passes
* [ ] updated documentation wherever necessary
* [ ] added or modified tests if necessary
* [ ] updated schemas and validators in [insights-data-schemas](https://github.com/RedHatInsights/insights-data-schemas) in case of input/output change
