### PR TITLE
[CCXDEV-12620] Add RulesResultsConsumer

### DIFF
--- a/ccx_messaging/consumers/rules_results_consumer.py
+++ b/ccx_messaging/consumers/rules_results_consumer.py
@@ -1,0 +1,105 @@
+"""Module containing the consumer for the Kafka topic produced by the Rules Processing service."""
+
+import json
+import logging
+import time
+import os
+from tempfile import NamedTemporaryFile
+from typing import Any
+
+
+from confluent_kafka import KafkaException
+from insights import dr
+from insights.core.exceptions import InvalidContentType
+
+from ccx_messaging.consumers.kafka_consumer import KafkaConsumer
+from ccx_messaging.error import CCXMessagingError
+from ccx_messaging.internal_pipeline import parse_rules_results_msg
+
+
+LOG = logging.getLogger(__name__)
+
+
+class RulesResultsConsumer(KafkaConsumer):
+    """Consumer for the topic produced by `idp_rule_processing_publisher.IDPRuleProcessingPublisher`."""  # noqa: E501
+
+    def get_url(self, input_msg: dict[str:str]) -> str:
+        """Retrieve path to the archive in the S3 storage from dictionary."""
+        return input_msg["file_path"]
+
+    def process_msg(self, msg):
+        """Process a single message received from the topic."""
+        if not msg:
+            LOG.debug("Empty record. Should not happen")
+            return
+
+        self.last_received_message_time = time.time()  # Base class thread control
+        if msg.error():
+            raise KafkaException(msg.error())
+
+        try:
+            # Deserialize
+            value = self.deserialize(msg)
+            with NamedTemporaryFile(mode="w", encoding="utf-8") as temp_file:
+                json.dump(value, temp_file)
+                temp_file.flush()
+                # Extend original Kafka message with path to temporary file
+                value["file_path"] = temp_file.name
+                # Core Messaging process
+                self.process(value)
+
+        except InvalidContentType as ex:
+            LOG.warning("The archive cannot be processed by Insights: %s", ex)
+            self.process_dead_letter(msg)
+
+        except CCXMessagingError as ex:
+            LOG.warning(
+                "Unexpected error processing incoming message. (%s): %s. Error: %s",
+                self.log_pattern,
+                msg.value(),
+                ex,
+            )
+            self.process_dead_letter(msg)
+
+        except TimeoutError as ex:
+            self.fire("on_process_timeout")
+            LOG.exception(ex)
+            self.process_dead_letter(msg)
+
+        except Exception as ex:  # pylint: disable=broad-exception-caught
+            LOG.exception(ex)
+            self.process_dead_letter(msg)
+
+    def deserialize(self, msg):
+        """Deserialize the message received from Kafka into a dictionary."""
+        if not msg:
+            raise CCXMessagingError("No incoming message: %s", msg)
+
+        try:
+            value = msg.value()
+        except AttributeError as ex:
+            raise CCXMessagingError("Invalid incoming message type: %s", type(msg)) from ex
+
+        LOG.debug("Deserializing incoming message(%s): %s", self.log_pattern, value)
+
+        if not value:
+            raise CCXMessagingError("Unable to read incoming message: %s", value)
+
+        deseralized_msg = parse_rules_results_msg(value)
+        LOG.debug("JSON message deserialized (%s): %s", self.log_pattern, deseralized_msg)
+        return deseralized_msg
+
+    def create_broker(self, input_msg: dict[str, Any]) -> dr.Broker:
+        """Create a suitable `Broker`."""
+        broker = dr.Broker()
+        broker["cluster_id"] = input_msg["metadata"]["cluster_id"]
+        broker["report_path"] = self.create_report_path(input_msg)
+        return broker
+
+    def create_report_path(self, input_msg):
+        """Construct report path from the original archive path."""
+        path, file_name = os.path.split(input_msg.get("path"))
+        archive_name = file_name.replace(".tar.gz", "")
+        new_path = path.replace("archives/compressed", "insights")
+        report_path = os.path.join(new_path, archive_name, "insights.json")
+        return report_path

--- a/ccx_messaging/internal_pipeline.py
+++ b/ccx_messaging/internal_pipeline.py
@@ -6,17 +6,17 @@ import logging
 import jsonschema
 
 from ccx_messaging.error import CCXMessagingError
-from ccx_messaging.schemas import ARCHIVE_SYNCED_SCHEMA
+from ccx_messaging.schemas import ARCHIVE_SYNCED_SCHEMA, RULES_RESULTS_SCHEMA
 
 
 LOG = logging.getLogger(__name__)
 
 
-def parse_archive_sync_msg(message: bytes) -> dict:
+def parse_msg(message: bytes, schema: dict) -> dict:
     """Parse a bytes messages into a dictionary, decoding encoded values."""
     try:
         deserialized_message = json.loads(message)
-        jsonschema.validate(instance=deserialized_message, schema=ARCHIVE_SYNCED_SCHEMA)
+        jsonschema.validate(instance=deserialized_message, schema=schema)
 
     except TypeError as ex:
         LOG.warning("Incorrect message type: %s", message)
@@ -32,3 +32,13 @@ def parse_archive_sync_msg(message: bytes) -> dict:
 
     LOG.debug("JSON schema validated: %s", deserialized_message)
     return deserialized_message
+
+
+def parse_archive_sync_msg(message: bytes) -> dict:
+    """Parse archive sync message into dictionary."""
+    return parse_msg(message, ARCHIVE_SYNCED_SCHEMA)
+
+
+def parse_rules_results_msg(message: bytes) -> dict:
+    """Parse rules results message into dictionary."""
+    return parse_msg(message, RULES_RESULTS_SCHEMA)

--- a/ccx_messaging/schemas.py
+++ b/ccx_messaging/schemas.py
@@ -78,3 +78,20 @@ ARCHIVE_SYNCED_SCHEMA = {
     },
     "required": ["path", "metadata"],
 }
+
+RULES_RESULTS_SCHEMA = {
+    "type": "object",
+    "properties": {
+        "path": {"type": "string"},
+        "metadata": {
+            "type": "object",
+            "properties": {
+                "cluster_id": {"type": "string"},
+                "external_organization": {"type": "string"},
+            },
+            "required": ["cluster_id"],
+        },
+        "report": {"type": "object"},
+    },
+    "required": ["path", "metadata", "report"],
+}

--- a/test/consumers/rules_results_consumer_test.py
+++ b/test/consumers/rules_results_consumer_test.py
@@ -1,0 +1,207 @@
+# Copyright 2025 Red Hat, Inc
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Module for testing `RulesResultsConsumer` class."""
+
+import json
+import os
+import pytest
+from unittest.mock import MagicMock, patch
+
+from confluent_kafka import KafkaException
+
+from ccx_messaging.consumers.rules_results_consumer import RulesResultsConsumer
+from ccx_messaging.error import CCXMessagingError
+
+
+from . import KafkaMessage
+
+
+_VALID_MESSAGE_CONTENT = {
+    "path": "archives/compressed/aa/aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee/202101/20/031044.tar.gz",
+    "metadata": {
+        "cluster_id": "aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee",
+    },
+    "report": {
+        "system": {},
+        "reports": [],
+        "skips": [],
+        "pass": [],
+        "info": [],
+    },
+}
+
+_INVALID_TYPE_VALUES = [
+    None,
+    42,
+    3.14,
+    True,
+    [],
+    {},
+]
+
+
+@patch("ccx_messaging.consumers.kafka_consumer.ConfluentConsumer", lambda *a, **k: MagicMock())
+def test_get_url():
+    """Test that `get_url` method retrieves path from correct field."""
+    consumer = RulesResultsConsumer(None, None, None, incoming_topic=None)
+    msg = {"file_path": "test"}
+    assert consumer.get_url(msg) == "test"
+
+
+@patch("ccx_messaging.consumers.kafka_consumer.ConfluentConsumer", lambda *a, **k: MagicMock())
+def test_get_url_invalid():
+    """Test that `get_url` method raises exception if `file_path` field is missing."""
+    consumer = RulesResultsConsumer(None, None, None, incoming_topic=None)
+    with pytest.raises(Exception):
+        consumer.get_url({})
+
+
+@patch("ccx_messaging.consumers.kafka_consumer.ConfluentConsumer", lambda *a, **k: MagicMock())
+def test_deserialize_valid_msg():
+    """Test that valid message is correctly deserialized."""
+    consumer = RulesResultsConsumer(None, None, None, incoming_topic=None)
+    msg = consumer.deserialize(KafkaMessage(json.dumps(_VALID_MESSAGE_CONTENT)))
+    assert msg == _VALID_MESSAGE_CONTENT
+
+
+@pytest.mark.parametrize("value", _INVALID_TYPE_VALUES)
+@patch("ccx_messaging.consumers.kafka_consumer.ConfluentConsumer")
+def test_deserialize_invalid_type(mock_consumer, value):
+    """Test that passing invalid data type to `deserialize` raises an exception."""
+    sut = RulesResultsConsumer(None, None, None, incoming_topic=None)
+    with pytest.raises(CCXMessagingError):
+        sut.deserialize(value)
+
+
+@pytest.mark.parametrize("value", _INVALID_TYPE_VALUES)
+@patch("ccx_messaging.consumers.kafka_consumer.ConfluentConsumer")
+def test_deserialize_invalid_type_as_kafka_message(mock_consumer, value):
+    """Test that passing invalid data type to `deserialize` raises an exception."""
+    sut = RulesResultsConsumer(None, None, None, incoming_topic=None)
+    with pytest.raises(CCXMessagingError):
+        sut.deserialize(KafkaMessage(value))
+
+
+_INVALID_MESSAGES = [
+    {
+        "metadata": {
+            "cluster_id": "aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee",
+        },
+        "report": {
+            "system": {},
+            "reports": [],
+            "skips": [],
+            "pass": [],
+            "info": [],
+        },
+    },
+    {
+        "path": "archives/compressed/aa/aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee/202101/20/031044.tar.gz",  # noqa: E501
+        "report": {
+            "system": {},
+            "reports": [],
+            "skips": [],
+            "pass": [],
+            "info": [],
+        },
+    },
+    {
+        "path": "archives/compressed/aa/aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee/202101/20/031044.tar.gz",  # noqa: E501
+        "metadata": {},
+        "report": {
+            "system": {},
+            "reports": [],
+            "skips": [],
+            "pass": [],
+            "info": [],
+        },
+    },
+    {
+        "path": "archives/compressed/aa/aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee/202101/20/031044.tar.gz",  # noqa: E501
+        "metadata": {
+            "cluster_id": "aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee",
+        },
+    },
+]
+
+
+@pytest.mark.parametrize("value", _INVALID_MESSAGES)
+@patch("ccx_messaging.consumers.kafka_consumer.ConfluentConsumer", lambda *a, **k: MagicMock())
+def test_deserialize_invalid_msg_format(value):
+    """Test that error is raised when deserializing messages with invalid format."""
+    sut = RulesResultsConsumer(None, None, None, incoming_topic=None)
+    with pytest.raises(CCXMessagingError):
+        sut.deserialize(KafkaMessage(json.dumps(value)))
+
+
+@patch("ccx_messaging.consumers.kafka_consumer.ConfluentConsumer", lambda *a, **k: MagicMock())
+def test_process_msg_temp_file():
+    """Test that the temporary file is created and removed during the message processing."""
+    file_name = ""
+
+    def test_file_exists(_, msg):
+        nonlocal file_name
+        assert "file_path" in msg
+        file_name = msg["file_path"]
+        assert os.path.exists(file_name)
+
+    consumer = RulesResultsConsumer(None, None, None, incoming_topic=None)
+    with patch("ccx_messaging.consumers.kafka_consumer.KafkaConsumer.process", test_file_exists):
+        consumer.process_msg(KafkaMessage(json.dumps(_VALID_MESSAGE_CONTENT)))
+    assert not os.path.exists(file_name)
+
+
+@patch("ccx_messaging.consumers.kafka_consumer.ConfluentConsumer", lambda *a, **k: MagicMock())
+def test_process_msg_raise_error():
+    """Test when the `process` message raises an error."""
+    consumer = RulesResultsConsumer(None, None, None, incoming_topic=None)
+    with pytest.raises(KafkaException):
+        consumer.process_msg(KafkaMessage(error=True))
+
+
+@pytest.mark.parametrize("value", _INVALID_MESSAGES)
+@patch("ccx_messaging.consumers.kafka_consumer.ConfluentConsumer", lambda *a, **k: MagicMock())
+def test_process_msg_invalid_format(value):
+    """Test when the `process` message raises an error."""
+    consumer = RulesResultsConsumer(None, None, None, incoming_topic=None)
+    with patch(
+        "ccx_messaging.consumers.rules_results_consumer.RulesResultsConsumer.process_dead_letter",
+    ) as dlq_mock:
+        consumer.process_msg(KafkaMessage(json.dumps(value)))
+        assert dlq_mock.called
+
+
+@patch("ccx_messaging.consumers.kafka_consumer.ConfluentConsumer", lambda *a, **k: MagicMock())
+def test_create_broker():
+    """Test that broker contains all expected fields."""
+    consumer = RulesResultsConsumer(None, None, None, incoming_topic=None)
+    with patch(
+        "ccx_messaging.consumers.rules_results_consumer.RulesResultsConsumer.create_report_path",
+    ) as create_path_mock:
+        create_path_mock.return_value = "mock_path"
+        broker = consumer.create_broker(_VALID_MESSAGE_CONTENT)
+        assert create_path_mock.called
+        assert "report_path" in broker.keys()
+        assert "cluster_id" in broker.keys()
+        assert broker["report_path"] == "mock_path"
+        assert broker["cluster_id"] == _VALID_MESSAGE_CONTENT["metadata"]["cluster_id"]
+
+
+@patch("ccx_messaging.consumers.kafka_consumer.ConfluentConsumer", lambda *a, **k: MagicMock())
+def test_create_report_path():
+    """Test that the report path is correctly created."""
+    consumer = RulesResultsConsumer(None, None, None, incoming_topic=None)
+    path = consumer.create_report_path(_VALID_MESSAGE_CONTENT)
+    assert path == "insights/aa/aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee/202101/20/031044/insights.json"


### PR DESCRIPTION
# Description

Add consumer that replaces `UploadReport` class from data-pipeline repository. New consumer utilizes existing `S3UploadEngine` from ccx-messaging instead of `S3Uploader` publisher from data-pipeline.

## Type of change

- New feature (non-breaking change which adds functionality)
- Unit tests (no changes in the code)

## Testing steps

Tested that upload works locally, wrote some unit tests.

## Checklist
* [x] `pre-commit run -a` passes
* [ ] updated documentation wherever necessary
* [x] added or modified tests if necessary
* [ ] updated schemas and validators in [insights-data-schemas](https://github.com/RedHatInsights/insights-data-schemas) in case of input/output change
