### PR TITLE
Fix sanity check for identity in broker creation

### DIFF
--- a/ccx_messaging/consumers/kafka_consumer.py
+++ b/ccx_messaging/consumers/kafka_consumer.py
@@ -269,8 +269,13 @@ class KafkaConsumer(Consumer):
         broker = dr.Broker()
 
         # Some engines expect some data for its own usage, like the following:
+        # (NOTE: The fields should be always present because of schema validation
+        # done in the other method, default values are just a sanity check.)
         org_id = (
-            input_msg.get("identity", {}).get("identity").get("internal", {}).get("org_id", None)
+            input_msg.get("identity", {})
+            .get("identity", {})
+            .get("internal", {})
+            .get("org_id", None)
         )
         date = datetime.fromisoformat(input_msg.get("timestamp", "0"))
 


### PR DESCRIPTION
# Description

Broker creation failed if the identity field in the message was missing / incomplete. 

## Type of change

- Bug fix (non-breaking change which fixes an issue)
- Unit tests (no changes in the code)

## Testing steps

NA

## Checklist
* [x] `pre-commit run -a` passes
* [ ] updated documentation wherever necessary
* [x] added or modified tests if necessary
* [ ] updated schemas and validators in [insights-data-schemas](https://github.com/RedHatInsights/insights-data-schemas) in case of input/output change
