### PR TITLE
Remove additions to parsed incoming message

### DIFF
--- a/ccx_messaging/consumers/kafka_consumer.py
+++ b/ccx_messaging/consumers/kafka_consumer.py
@@ -111,9 +111,8 @@ class KafkaConsumer(Consumer):
         try:
             url = input_msg["url"]
             LOG.debug(
-                "Extracted URL from input message: %s (%s)",
+                "Extracted URL from input message: %s",
                 url,
-                get_stringfied_record(input_msg),
             )
             return url
 
@@ -199,11 +198,6 @@ class KafkaConsumer(Consumer):
                 LOG.info("Processing message using OCP rules version %s", self.ocp_rules_version)
             # Deserialize
             value = self.deserialize(msg)
-
-            # Enrich the deserialized message with some context info
-            value["topic"] = msg.topic()
-            value["partition"] = msg.partition()
-            value["offset"] = msg.offset()
 
             # Core Messaging process
             self.process(value)
@@ -302,11 +296,3 @@ class KafkaConsumer(Consumer):
             self.dead_letter_queue_topic,
             msg.value(),
         )
-
-
-def get_stringfied_record(input_record: dict) -> str:
-    """Retrieve a string with information about the received record ready to log."""
-    return (
-        f"topic: '{input_record.get('topic')}', partition: {input_record.get('partition')}, "
-        f"offset: {input_record.get('offset')}, timestamp: {input_record.get('timestamp')}"
-    )

--- a/ccx_messaging/publishers/dvo_metrics_publisher.py
+++ b/ccx_messaging/publishers/dvo_metrics_publisher.py
@@ -86,10 +86,3 @@ class DVOMetricsPublisher(KafkaPublisher):
             output_msg["AccountNumber"],
             output_msg["ClusterName"],
         )
-
-        log.debug(
-            "Status: Success; Topic: %s; Partition: %s; Offset: %s; ",
-            input_msg.get("topic"),
-            input_msg.get("partition"),
-            input_msg.get("offset"),
-        )

--- a/ccx_messaging/publishers/rule_processing_publisher.py
+++ b/ccx_messaging/publishers/rule_processing_publisher.py
@@ -134,14 +134,6 @@ class RuleProcessingPublisher(KafkaPublisher):
                 output_msg["Version"],
             )
 
-            log.debug(
-                "Status: Success; Topic: %s; Partition: %s; Offset: %s; LastChecked: %s",
-                input_msg.get("topic"),
-                input_msg.get("partition"),
-                input_msg.get("offset"),
-                msg_timestamp,
-            )
-
         except KeyError as err:
             raise CCXMessagingError("Missing expected keys in the input message") from err
 

--- a/ccx_messaging/publishers/synced_archive_publisher.py
+++ b/ccx_messaging/publishers/synced_archive_publisher.py
@@ -41,10 +41,3 @@ class SyncedArchivePublisher(KafkaPublisher):
             output_msg["original_path"],
             output_msg["metadata"],
         )
-
-        LOG.debug(
-            "Status: Success; Topic: %s; Partition: %s; Offset: %s; ",
-            input_msg.get("topic"),
-            input_msg.get("partition"),
-            input_msg.get("offset"),
-        )

--- a/ccx_messaging/publishers/workloads_info_publisher.py
+++ b/ccx_messaging/publishers/workloads_info_publisher.py
@@ -103,14 +103,6 @@ class WorkloadInfoPublisher(KafkaPublisher):
                 output_msg["Version"],
             )
 
-            log.debug(
-                "Status: Success; Topic: %s; Partition: %s; Offset: %s; LastChecked: %s",
-                input_msg["topic"],
-                input_msg["partition"],
-                input_msg["offset"],
-                msg_timestamp,
-            )
-
         except (KeyError, TypeError, UnicodeEncodeError, JSONDecodeError) as err:
             log.warning("Error encoding the response to publish: %s", message)
             raise CCXMessagingError("Error encoding the response to publish") from err

--- a/test/consumers/kafka_consumer_test.py
+++ b/test/consumers/kafka_consumer_test.py
@@ -377,21 +377,10 @@ def test_process_msg_not_handled():
 @patch("ccx_messaging.consumers.kafka_consumer.ConfluentConsumer", lambda *a, **k: MagicMock())
 @patch("ccx_messaging.consumers.kafka_consumer.KafkaConsumer.handles", lambda *a, **k: True)
 @patch("ccx_messaging.consumers.kafka_consumer.KafkaConsumer.fire", lambda *a, **k: None)
-@patch(
-    "ccx_messaging.consumers.kafka_consumer.get_stringfied_record",
-    lambda *a, **k: None,
-)
 def test_process_msg_handled(value, expected):
     """Check if `process_msg` behaves as expected."""
     sut = KafkaConsumer(None, None, None, None)
     input_msg = KafkaMessage(value)
-    expected.update(
-        {
-            "topic": input_msg.topic(),
-            "partition": input_msg.partition(),
-            "offset": input_msg.offset(),
-        }
-    )
 
     with patch("ccx_messaging.consumers.kafka_consumer.KafkaConsumer.process") as process_mock:
         sut.process_msg(input_msg)
@@ -402,10 +391,6 @@ def test_process_msg_handled(value, expected):
 @patch("ccx_messaging.consumers.kafka_consumer.ConfluentConsumer", lambda *a, **k: MagicMock())
 @patch("ccx_messaging.consumers.kafka_consumer.KafkaConsumer.handles", lambda *a, **k: True)
 @patch("ccx_messaging.consumers.kafka_consumer.KafkaConsumer.fire", lambda *a, **k: None)
-@patch(
-    "ccx_messaging.consumers.kafka_consumer.get_stringfied_record",
-    lambda *a, **k: None,
-)
 def test_non_processed_to_dlq(value, expected):
     """Check that, if in some point an exception is raised, DLQ will handle it."""
     sut = KafkaConsumer(None, None, None, None)


### PR DESCRIPTION
# Description

Currently the `KafkaConsumer` is adding information relative to Kafka topic, partition and offset into the incoming message, creating an unnecessary coupling between consumers and other components.

## Type of change

- Refactor (refactoring code, removing useless files)

## Testing steps

Tested locally

## Checklist
* [x] `pre-commit run -a` passes
* [ ] updated documentation wherever necessary
* [x] added or modified tests if necessary
* [ ] updated schemas and validators in [insights-data-schemas](https://github.com/RedHatInsights/insights-data-schemas) in case of input/output change
