### PR TITLE
Use strings to store date time information in the broker

### DIFF
--- a/ccx_messaging/consumers/kafka_consumer.py
+++ b/ccx_messaging/consumers/kafka_consumer.py
@@ -276,13 +276,13 @@ class KafkaConsumer(Consumer):
         broker["org_id"] = org_id
         broker["cluster_id"] = input_msg["cluster_name"]
         broker["original_path"] = input_msg["url"]
-        broker["year"] = date.year
-        broker["month"] = date.month
-        broker["day"] = date.day
-        broker["time"] = f"{date.hour}:{date.minute}:{date.second}"
-        broker["hour"] = date.hour
-        broker["minute"] = date.minute
-        broker["second"] = date.second
+        broker["year"] = f"{date.year:04}"
+        broker["month"] = f"{date.month:02}"
+        broker["day"] = f"{date.day:02}"
+        broker["hour"] = f"{date.hour:02}"
+        broker["minute"] = f"{date.minute:02}"
+        broker["second"] = f"{date.second:02}"
+        broker["time"] = f"{date.hour:02}{date.minute:02}{date.second:02}"
 
         return broker
 

--- a/test/consumers/kafka_consumer_test.py
+++ b/test/consumers/kafka_consumer_test.py
@@ -492,6 +492,7 @@ def test_broker_creation(deserialized_msg):
     """Check that create_broker returns the expected values."""
     sut = KafkaConsumer(None, None, None, "topic")
     broker = sut.create_broker(deserialized_msg)
+    msg_timestamp = datetime.datetime.fromisoformat(deserialized_msg["timestamp"])
 
     assert broker["original_path"] == deserialized_msg["url"]
     identity = (
@@ -501,6 +502,15 @@ def test_broker_creation(deserialized_msg):
         .get("org_id", None)
     )
     assert broker["org_id"] == identity
+    assert broker["year"] == f"{msg_timestamp.year:04}"
+    assert broker["month"] == f"{msg_timestamp.month:02}"
+    assert broker["day"] == f"{msg_timestamp.day:02}"
+    assert broker["hour"] == f"{msg_timestamp.hour:02}"
+    assert broker["minute"] == f"{msg_timestamp.minute:02}"
+    assert broker["second"] == f"{msg_timestamp.second:02}"
+    assert broker["time"] == (
+        f"{msg_timestamp.hour:02}{msg_timestamp.minute:02}{msg_timestamp.second:02}"
+    )
 
 
 @patch("ccx_messaging.consumers.kafka_consumer.ConfluentConsumer", lambda *a, **k: MagicMock())


### PR DESCRIPTION
# Description

The `KafkaConsumer` set up the broker to store some information relative to the timestamp of the received archive. Those data is used by some engines to build the full timestamp string (for example, `S3UploadEngine` to generate the destination path of the uploaded archive).

This change ensures that the date and time fields have a regular format of 2 digits instead of storing an integer.

## Type of change

- Refactor (refactoring code, removing useless files)

## Testing steps

Just locally and unit tests

## Checklist
* [x] `pre-commit run -a` passes
* [ ] updated documentation wherever necessary
* [ ] added or modified tests if necessary
* [ ] updated schemas and validators in [insights-data-schemas](https://github.com/RedHatInsights/insights-data-schemas) in case of input/output change
