### PR TITLE
Add deploy files for internal data pipelines related services [archive-sync]

### DIFF
--- a/deploy/archive-sync.yaml
+++ b/deploy/archive-sync.yaml
@@ -188,8 +188,8 @@ objects:
           kwargs:
             dest_bucket: ${TARGET_S3_BUCKET}
             archives_path_prefix: archives/compressed
-      publisher:
-        name: ccx_messaging.publishers.synced_archive_publisher.SyncedArchivePublisher
+        publisher:
+          name: ccx_messaging.publishers.synced_archive_publisher.SyncedArchivePublisher
           kwargs:
             outgoing_topic: ${KAFKA_OUTGOING_TOPIC}
             bootstrap.servers: ${KAFKA_CONSUMER_SERVER}

--- a/deploy/archive-sync.yaml
+++ b/deploy/archive-sync.yaml
@@ -193,8 +193,8 @@ objects:
           kwargs:
             dest_bucket: ${TARGET_S3_BUCKET}
             archives_path_prefix: archives/compressed
-        publisher:
-          name: ccx_messaging.publishers.rule_processing_publisher.RuleProcessingPublisher
+      publisher:
+        name: ccx_messaging.publishers.synced_archive_publisher.SyncedArchivePublisher
           kwargs:
             outgoing_topic: ${KAFKA_OUTGOING_TOPIC}
             bootstrap.servers: ${KAFKA_CONSUMER_SERVER}
@@ -304,7 +304,7 @@ parameters:
   required: true
 
 - name: TARGET_S3_BUCKET
-  value: target-bucket
+  value: ccx-bucket
   required: true
 
 - name: CLOUDWATCH_DEBUG

--- a/deploy/archive-sync.yaml
+++ b/deploy/archive-sync.yaml
@@ -152,6 +152,9 @@ objects:
       - replicas: 3  # TODO needed?
         partitions: 1  # TODO needed?
         topicName: ${PAYLOAD_TRACKER_TOPIC}
+      - replicas: 1  # TODO find right param
+        partitions: 1  # TODO find right param
+        topicName: ${KAFKA_OUTGOING_TOPIC}
 
 - kind: ConfigMap
   apiVersion: v1
@@ -193,7 +196,10 @@ objects:
             dest_bucket: ${TARGET_S3_BUCKET}
             archives_path_prefix: archives/compressed
         publisher:
-          name: insights_messaging.publishers.Publisher
+          name: ccx_messaging.publishers.rule_processing_publisher.RuleProcessingPublisher
+          kwargs:
+            outgoing_topic: ${KAFKA_OUTGOING_TOPIC}
+            bootstrap.servers: ${KAFKA_CONSUMER_SERVER}
         watchers:
           - name: ccx_messaging.watchers.stats_watcher.StatsWatcher
             kwargs:
@@ -274,6 +280,9 @@ parameters:
 
 - name: KAFKA_INCOMING_TOPIC
   value: platform.upload.announce
+  required: true
+- name: KAFKA_OUTGOING_TOPIC
+  value: ccx.archive.synced
   required: true
 - name: KAFKA_DEAD_LETTER_QUEUE_TOPIC
   value: ccx.archive.sync.dead.letter.queue

--- a/deploy/archive-sync.yaml
+++ b/deploy/archive-sync.yaml
@@ -144,9 +144,6 @@ objects:
 
     kafkaTopics:
       - topicName: ${KAFKA_INCOMING_TOPIC}
-      - topicName: ${KAFKA_DEAD_LETTER_QUEUE_TOPIC}
-        replicas: 1
-        partitions: 1
       - topicName: ${PAYLOAD_TRACKER_TOPIC}
         partitions: 1
       - topicName: ${KAFKA_OUTGOING_TOPIC}
@@ -178,7 +175,6 @@ objects:
             max.poll.interval.ms: 600000
             heartbeat.interval.ms: 10000
             session.timeout.ms: 20000
-            dead_letter_queue_topic: ${KAFKA_DEAD_LETTER_QUEUE_TOPIC}
         downloader:
           name: ccx_messaging.downloaders.http_downloader.HTTPDownloader
           kwargs:
@@ -273,9 +269,6 @@ parameters:
   required: true
 - name: KAFKA_OUTGOING_TOPIC
   value: ccx.archive.synced
-  required: true
-- name: KAFKA_DEAD_LETTER_QUEUE_TOPIC
-  value: ccx.archive.sync.dead.letter.queue
   required: true
 - name: PAYLOAD_TRACKER_TOPIC
   value: platform.payload-status

--- a/deploy/archive-sync.yaml
+++ b/deploy/archive-sync.yaml
@@ -204,7 +204,6 @@ objects:
               prometheus_port: 8000
           - name: ccx_messaging.watchers.payload_tracker_watcher.PayloadTrackerWatcher
             kwargs:
-              prometheus_port: 8000
               bootstrap.servers: ${KAFKA_CONSUMER_SERVER}
               topic: ${PAYLOAD_TRACKER_TOPIC}
         logging:

--- a/deploy/archive-sync.yaml
+++ b/deploy/archive-sync.yaml
@@ -265,7 +265,7 @@ parameters:
   value: '8'
 
 - name: KAFKA_INCOMING_TOPIC
-  value: platform.upload.announce
+  value: ccx.new.archive.io
   required: true
 - name: KAFKA_OUTGOING_TOPIC
   value: ccx.archive.synced

--- a/deploy/archive-sync.yaml
+++ b/deploy/archive-sync.yaml
@@ -143,18 +143,13 @@ objects:
               memory: ${MEMORY_LIMIT}
 
     kafkaTopics:
-      - replicas: 16  # TODO needed?
-        partitions: 3  # TODO needed?
-        topicName: ${KAFKA_INCOMING_TOPIC}
-      - replicas: 1
+      - topicName: ${KAFKA_INCOMING_TOPIC}
+      - topicName: ${KAFKA_DEAD_LETTER_QUEUE_TOPIC}
+        replicas: 1
         partitions: 1
-        topicName: ${KAFKA_DEAD_LETTER_QUEUE_TOPIC}
-      - replicas: 3  # TODO needed?
-        partitions: 1  # TODO needed?
-        topicName: ${PAYLOAD_TRACKER_TOPIC}
-      - replicas: 1  # TODO find right param
-        partitions: 1  # TODO find right param
-        topicName: ${KAFKA_OUTGOING_TOPIC}
+      - topicName: ${PAYLOAD_TRACKER_TOPIC}
+        partitions: 1
+      - topicName: ${KAFKA_OUTGOING_TOPIC}
 
 - kind: ConfigMap
   apiVersion: v1
@@ -168,7 +163,7 @@ objects:
         packages:
         - ccx_messaging
       service:
-        extract_timeout:
+        extract_timeout:  # TODO validate
         extract_tmp_dir:
         format: insights.formats._json.JsonFormat
         target_components: []
@@ -286,7 +281,7 @@ parameters:
   value: platform.payload-status
   required: true
 - name: KAFKA_GROUP_ID
-  value: archive_sync_app  # TODO update for ols
+  value: archive_sync_app
   required: true
 - name: KAFKA_CONSUMER_SERVER
   description: App-SRE Kafka

--- a/deploy/archive-sync.yaml
+++ b/deploy/archive-sync.yaml
@@ -202,8 +202,12 @@ objects:
             bootstrap.servers: ${KAFKA_CONSUMER_SERVER}
         watchers:
           - name: ccx_messaging.watchers.stats_watcher.StatsWatcher
+          - name: ccx_messaging.watchers.payload_tracker_watcher.PayloadTrackerWatcher
             kwargs:
               prometheus_port: 8000
+              bootstrap.servers: ${KAFKA_CONSUMER_SERVER}
+              topic: ${PAYLOAD_TRACKER_TOPIC}
+
 
         logging:
           version: 1

--- a/deploy/archive-sync.yaml
+++ b/deploy/archive-sync.yaml
@@ -104,7 +104,7 @@ objects:
                   name: cloudwatch
                   key: aws_secret_access_key
                   optional: true
-            - name: PYTHONUNBUFFERED  # TODO needed?
+            - name: PYTHONUNBUFFERED
               value: "1"
           readinessProbe:
             httpGet:

--- a/deploy/archive-sync.yaml
+++ b/deploy/archive-sync.yaml
@@ -17,7 +17,7 @@ objects:
       apiVersion: apps/v1
       kind: Deployment
       name: archive-sync-instance
-    targetCPUUtilizationPercentage: 50
+    targetCPUUtilizationPercentage: 30
 - apiVersion: cloud.redhat.com/v1alpha1
   kind: ClowdApp
   metadata:

--- a/deploy/archive-sync.yaml
+++ b/deploy/archive-sync.yaml
@@ -4,6 +4,7 @@ kind: Template
 metadata:
   name: archive-sync
 objects:
+
 - kind: HorizontalPodAutoscaler
   apiVersion: autoscaling/v1
   metadata:

--- a/deploy/archive-sync.yaml
+++ b/deploy/archive-sync.yaml
@@ -32,6 +32,7 @@ objects:
 #      iqePlugin: ccx
     deployments:
       - name: instance
+        replicas: ${{MIN_REPLICAS}}
         webServices:
           public:
             enabled: false

--- a/deploy/archive-sync.yaml
+++ b/deploy/archive-sync.yaml
@@ -200,6 +200,8 @@ objects:
             bootstrap.servers: ${KAFKA_CONSUMER_SERVER}
         watchers:
           - name: ccx_messaging.watchers.stats_watcher.StatsWatcher
+            kwargs:
+              prometheus_port: 8000
           - name: ccx_messaging.watchers.payload_tracker_watcher.PayloadTrackerWatcher
             kwargs:
               prometheus_port: 8000

--- a/deploy/archive-sync.yaml
+++ b/deploy/archive-sync.yaml
@@ -12,7 +12,7 @@ objects:
     name: archive-sync
   spec:
     minReplicas: ${{MIN_REPLICAS}}
-    maxReplicas: 8
+    maxReplicas: ${{MAX_REPLICAS}}
     scaleTargetRef:
       apiVersion: apps/v1
       kind: Deployment

--- a/deploy/archive-sync.yaml
+++ b/deploy/archive-sync.yaml
@@ -4,6 +4,20 @@ kind: Template
 metadata:
   name: archive-sync
 objects:
+- kind: HorizontalPodAutoscaler
+  apiVersion: autoscaling/v1
+  metadata:
+    labels:
+      app: ccx-data-pipeline
+    name: archive-sync
+  spec:
+    minReplicas: ${{MIN_REPLICAS}}
+    maxReplicas: ${{MAX_REPLICAS}}
+    scaleTargetRef:
+      apiVersion: apps/v1
+      kind: Deployment
+      name: archive-sync-instance
+    targetCPUUtilizationPercentage: 50
 - apiVersion: cloud.redhat.com/v1alpha1
   kind: ClowdApp
   metadata:
@@ -23,12 +37,6 @@ objects:
             enabled: false
           metrics:
             enabled: true
-        autoScalerSimple:  # TODO check is working
-          replicas:
-            min: ${{MIN_REPLICAS}}
-            max: ${{MAX_REPLICAS}}
-          cpu:
-            scaleAtUtilization: 75
         podSpec:
           image: ${IMAGE}:${IMAGE_TAG}
           command: ["ccx-messaging"]

--- a/deploy/archive-sync.yaml
+++ b/deploy/archive-sync.yaml
@@ -17,7 +17,8 @@ objects:
       apiVersion: apps/v1
       kind: Deployment
       name: archive-sync-instance
-    targetCPUUtilizationPercentage: 30
+    targetCPUUtilizationPercentage: 50
+
 - apiVersion: cloud.redhat.com/v1alpha1
   kind: ClowdApp
   metadata:

--- a/deploy/archive-sync.yaml
+++ b/deploy/archive-sync.yaml
@@ -167,7 +167,7 @@ objects:
         packages:
         - ccx_messaging
       service:
-        extract_timeout:  # TODO validate
+        extract_timeout:
         extract_tmp_dir:
         format: insights.formats._json.JsonFormat
         target_components: []

--- a/deploy/archive-sync.yaml
+++ b/deploy/archive-sync.yaml
@@ -184,12 +184,10 @@ objects:
             heartbeat.interval.ms: 10000
             session.timeout.ms: 20000
             dead_letter_queue_topic: ${KAFKA_DEAD_LETTER_QUEUE_TOPIC}
-
         downloader:
           name: ccx_messaging.downloaders.http_downloader.HTTPDownloader
           kwargs:
             allow_unsafe_links: ${ALLOW_UNSAFE_LINKS}
-
         engine:
           name: ccx_messaging.engines.s3_upload_engine.S3UploadEngine
           kwargs:
@@ -207,8 +205,6 @@ objects:
               prometheus_port: 8000
               bootstrap.servers: ${KAFKA_CONSUMER_SERVER}
               topic: ${PAYLOAD_TRACKER_TOPIC}
-
-
         logging:
           version: 1
           disable_existing_loggers: false
@@ -218,27 +214,21 @@ objects:
               class: logging.StreamHandler
               stream: ext://sys.stdout
               formatter: default
-
           formatters:
             default:
               format: '%(asctime)s %(name)s %(levelname)-8s %(message)s'
               datefmt: '%Y-%m-%d %H:%M:%S'
-
           root:
             level: ${LOGLEVEL_ROOT}
             handlers:
               - default
-
           loggers:
             ccx_messaging:
               level: ${LOGLEVEL_CCX_MESSAGING}
-
             insights_messaging:
               level: ${LOGLEVEL_INSIGHTS_MESSAGING}
-
             insights:
               level: ${LOGLEVEL_INSIGHTS}
-
             kafka:
               level: ${LOGLEVEL_KAFKA}
 

--- a/deploy/archive-sync.yaml
+++ b/deploy/archive-sync.yaml
@@ -275,38 +275,28 @@ parameters:
 
 - name: KAFKA_INCOMING_TOPIC
   value: ccx.new.archive.io
-  required: true
 - name: KAFKA_OUTGOING_TOPIC
   value: ccx.archive.synced
-  required: true
 - name: PAYLOAD_TRACKER_TOPIC
   value: platform.payload-status
-  required: true
 - name: KAFKA_GROUP_ID
   value: archive_sync_app
-  required: true
 - name: KAFKA_CONSUMER_SERVER
   description: App-SRE Kafka
   value: mq-kafka:29092
-  required: true
 - description: Service name for filtering received Kafka message from announce topic
   name: KAFKA_PLATFORM_SERVICE
-  required: true
   value: openshift
 - name: KAFKA_CONSUMER_SECURITY_PROTOCOL
   value: SASL_SSL
-  required: true
 - name: KAFKA_CONSUMER_SASL_MECHANISM
   value: SCRAM-SHA-512
-  required: true
 
 - name: TARGET_S3_BUCKET
   value: ccx-bucket
-  required: true
 
 - name: CLOUDWATCH_DEBUG
   value: "false"
-  required: true
 - name: CW_LOG_STREAM
   value: "archive-sync"
 - name: ALLOW_UNSAFE_LINKS

--- a/deploy/archive-sync.yaml
+++ b/deploy/archive-sync.yaml
@@ -12,13 +12,11 @@ objects:
     envName: ${ENV_NAME}
     objectStore:
       - ${TARGET_S3_BUCKET}
-    testing:
-      iqePlugin: ccx
-    dependencies:
-      - ingress
+#    testing:
+#      iqePlugin: ccx
     deployments:
       - name: instance
-        minReplicas: ${{MIN_REPLICAS}}
+        replicas: ${{MIN_REPLICAS}}
         webServices:
           public:
             enabled: false
@@ -26,6 +24,12 @@ objects:
             enabled: false
           metrics:
             enabled: true
+        autoScalerSimple:  # TODO check is working
+          replicas:
+            min: ${{MIN_REPLICAS}}
+            max: ${{MAX_REPLICAS}}
+          cpu:
+            scaleAtUtilization: 75
         podSpec:
           image: ${IMAGE}:${IMAGE_TAG}
           command: ["ccx-messaging"]
@@ -91,19 +95,8 @@ objects:
                   name: cloudwatch
                   key: aws_secret_access_key
                   optional: true
-
-            - name: LOGLEVEL_CCX_MESSAGING
-              value: ${LOGLEVEL_CCX_MESSAGING}
-            - name: LOGLEVEL_INSIGHTS_MESSAGING
-              value: ${LOGLEVEL_INSIGHTS_MESSAGING}
-            - name: LOGLEVEL_INSIGHTS
-              value: ${LOGLEVEL_INSIGHTS}
-            - name: LOGLEVEL_KAFKA
-              value: ${LOGLEVEL_KAFKA}
-            - name: LOGLEVEL_STDOUT
-              value: ${LOGLEVEL_STDOUT}
-            - name: LOGLEVEL_ROOT
-              value: ${LOGLEVEL_ROOT}
+            - name: PYTHONUNBUFFERED  # TODO needed?
+              value: "1"
           readinessProbe:
             httpGet:
               path: /metrics
@@ -150,14 +143,14 @@ objects:
               memory: ${MEMORY_LIMIT}
 
     kafkaTopics:
-      - replicas: 16
-        partitions: 3
+      - replicas: 16  # TODO needed?
+        partitions: 3  # TODO needed?
         topicName: ${KAFKA_INCOMING_TOPIC}
       - replicas: 1
         partitions: 1
         topicName: ${KAFKA_DEAD_LETTER_QUEUE_TOPIC}
-      - replicas: 3
-        partitions: 1
+      - replicas: 3  # TODO needed?
+        partitions: 1  # TODO needed?
         topicName: ${PAYLOAD_TRACKER_TOPIC}
 
 - kind: ConfigMap
@@ -172,8 +165,8 @@ objects:
         packages:
         - ccx_messaging
       service:
-        extract_timeout: ${EXTRACT_TIMEOUT}
-        extract_tmp_dir: ${EXTRACT_TMP_DIR}
+        extract_timeout:
+        extract_tmp_dir:
         format: insights.formats._json.JsonFormat
         target_components: []
         consumer:
@@ -211,7 +204,7 @@ objects:
           disable_existing_loggers: false
           handlers:
             default:
-              level: ${LOGLEVEL_STDOUT:INFO}
+              level: ${LOGLEVEL_STDOUT}
               class: logging.StreamHandler
               stream: ext://sys.stdout
               formatter: default
@@ -222,22 +215,22 @@ objects:
               datefmt: '%Y-%m-%d %H:%M:%S'
 
           root:
-            level: ${LOGLEVEL_ROOT:WARNING}
+            level: ${LOGLEVEL_ROOT}
             handlers:
               - default
 
           loggers:
             ccx_messaging:
-              level: ${LOGLEVEL_CCX_MESSAGING:DEBUG}
+              level: ${LOGLEVEL_CCX_MESSAGING}
 
             insights_messaging:
-              level: ${LOGLEVEL_INSIGHTS_MESSAGING:DEBUG}
+              level: ${LOGLEVEL_INSIGHTS_MESSAGING}
 
             insights:
-              level: ${LOGLEVEL_INSIGHTS:WARNING}
+              level: ${LOGLEVEL_INSIGHTS}
 
             kafka:
-              level: ${LOGLEVEL_KAFKA:INFO}
+              level: ${LOGLEVEL_KAFKA}
 
 - kind: Service
   apiVersion: v1
@@ -275,15 +268,12 @@ parameters:
 - description: Minimum number of pods to use when autoscaling is enabled
   name: MIN_REPLICAS
   value: '1'
-- description: Minimum number of pods to use when autoscaling is enabled
+- description: Maximum number of pods to use when autoscaling is enabled
   name: MAX_REPLICAS
-  value: '1'
+  value: '8'
 
 - name: KAFKA_INCOMING_TOPIC
   value: platform.upload.announce
-  required: true
-- name: KAFKA_SYNCED_TOPIC
-  value: eph-archive-synced
   required: true
 - name: KAFKA_DEAD_LETTER_QUEUE_TOPIC
   value: ccx.archive.sync.dead.letter.queue
@@ -292,10 +282,10 @@ parameters:
   value: platform.payload-status
   required: true
 - name: KAFKA_GROUP_ID
-  value: archive_sync_app
+  value: archive_sync_app  # TODO update for ols
   required: true
 - name: KAFKA_CONSUMER_SERVER
-  description: External data pipeline Kafka
+  description: App-SRE Kafka
   value: mq-kafka:29092
   required: true
 - description: Service name for filtering received Kafka message from announce topic

--- a/deploy/archive-sync.yaml
+++ b/deploy/archive-sync.yaml
@@ -16,7 +16,6 @@ objects:
 #      iqePlugin: ccx
     deployments:
       - name: instance
-        replicas: ${{MIN_REPLICAS}}
         webServices:
           public:
             enabled: false

--- a/deploy/archive-sync.yaml
+++ b/deploy/archive-sync.yaml
@@ -12,7 +12,7 @@ objects:
     name: archive-sync
   spec:
     minReplicas: ${{MIN_REPLICAS}}
-    maxReplicas: ${{MAX_REPLICAS}}
+    maxReplicas: 8
     scaleTargetRef:
       apiVersion: apps/v1
       kind: Deployment

--- a/deploy/archive-sync.yaml
+++ b/deploy/archive-sync.yaml
@@ -32,7 +32,6 @@ objects:
 #      iqePlugin: ccx
     deployments:
       - name: instance
-        replicas: ${{MIN_REPLICAS}}
         webServices:
           public:
             enabled: false

--- a/deploy/archive-sync.yaml
+++ b/deploy/archive-sync.yaml
@@ -53,11 +53,11 @@ objects:
             - name: KAFKA_PLATFORM_SERVICE
               value: ${KAFKA_PLATFORM_SERVICE}
             - name: KAFKA_CONSUMER_SERVER
-              value: ${KAFKA_CONSUMER_SERVER}
+              value: ${KAFKA_SERVER}
             - name: KAFKA_CONSUMER_SECURITY_PROTOCOL
-              value: ${KAFKA_CONSUMER_SECURITY_PROTOCOL}
+              value: ${KAFKA_SECURITY_PROTOCOL}
             - name: KAFKA_CONSUMER_SASL_MECHANISM
-              value: ${KAFKA_CONSUMER_SASL_MECHANISM}
+              value: ${KAFKA_SASL_MECHANISM}
             - name: KAFKA_INCOMING_TOPIC
               value: ${KAFKA_INCOMING_TOPIC}
 
@@ -179,7 +179,7 @@ objects:
             incoming_topic: ${KAFKA_INCOMING_TOPIC}
             platform_service: ${KAFKA_PLATFORM_SERVICE}
             group.id: ${KAFKA_GROUP_ID}
-            bootstrap.servers: ${KAFKA_CONSUMER_SERVER}
+            bootstrap.servers: ${KAFKA_SERVER}
             processing_timeout_s: 0
             max.poll.interval.ms: 600000
             heartbeat.interval.ms: 10000
@@ -197,14 +197,14 @@ objects:
           name: ccx_messaging.publishers.synced_archive_publisher.SyncedArchivePublisher
           kwargs:
             outgoing_topic: ${KAFKA_OUTGOING_TOPIC}
-            bootstrap.servers: ${KAFKA_CONSUMER_SERVER}
+            bootstrap.servers: ${KAFKA_SERVER}
         watchers:
           - name: ccx_messaging.watchers.stats_watcher.StatsWatcher
             kwargs:
               prometheus_port: 8000
           - name: ccx_messaging.watchers.payload_tracker_watcher.PayloadTrackerWatcher
             kwargs:
-              bootstrap.servers: ${KAFKA_CONSUMER_SERVER}
+              bootstrap.servers: ${KAFKA_SERVER}
               topic: ${PAYLOAD_TRACKER_TOPIC}
         logging:
           version: 1
@@ -281,15 +281,15 @@ parameters:
   value: platform.payload-status
 - name: KAFKA_GROUP_ID
   value: archive_sync_app
-- name: KAFKA_CONSUMER_SERVER
+- name: KAFKA_SERVER
   description: App-SRE Kafka
   value: mq-kafka:29092
 - description: Service name for filtering received Kafka message from announce topic
   name: KAFKA_PLATFORM_SERVICE
   value: openshift
-- name: KAFKA_CONSUMER_SECURITY_PROTOCOL
+- name: KAFKA_SECURITY_PROTOCOL
   value: SASL_SSL
-- name: KAFKA_CONSUMER_SASL_MECHANISM
+- name: KAFKA_SASL_MECHANISM
   value: SCRAM-SHA-512
 
 - name: TARGET_S3_BUCKET


### PR DESCRIPTION
# Description

Refactor archive-sync deploy file:

- comment testing: test are not on IQE
- replace minReplicas with replicas: as the former is deprecated
- add HPA
- remove log related envvars
- add PYTHONUNBUFFERED envvar
- empty extract related variables: as in ccx-data-pipeline service
- use log level template variables in logging config
- set max replicas
- remove unused template variables
- add outgoing kafka topic and publisher
- add payload tracker watcher
- remove dead letter queue references
- use `ccx.new.archive.io` as incoming topic
- remove `required` from parameters that have a default value

Related to [CCXDEV-14674](https://issues.redhat.com/browse/CCXDEV-14674)

## Type of change

- New feature (non-breaking change which adds functionality)
- Refactor (refactoring code, removing useless files)

## Testing steps

Deployed to ephemeral with `bonfire deploy ccx-data-pipeline --ref-env insights-production --frontends false  --namespace $ns -c config-file.yml --component ccx-data-pipeline --timeout 60`

using as config-file.yml

```
apps:
- name: ccx-data-pipeline
  components:
  - name: ccx-data-pipeline
    host: github
    repo: ikerreyes/insights-ccx-messaging
    path: /deploy/archive-sync.yaml
    ref: CCXDEV-14674
    parameters:
      IMAGE: quay.io/redhat-user-workloads/obsint-processing-tenant/ccx-messaging/ccx-messaging
      IMAGE_TAG: f1f19b637d811112443ffa55ea7ccf1e87a99d44
      KAFKA_INCOMING_TOPIC: platform.upload.announce
```

and then uploaded an archive to that ephemeral env. 

I have check that the archive ends in minIO instance and there is a published message kafka on the outgoing topic ```{"path": "archives/compressed/18/181862b9-c53b-4ea9-ae22-ac4415e2cf21/202503/06/132530.tar.gz", "original_path": "http://env-ephemeral-kyzn6l-minio.ephemeral-kyzn6l.svc:9000/insights-upload-perma/ingress-service-ffbf988d4-zgxnx/...", "metadata": {"cluster_id": "181862b9-c53b-4ea9-ae22-ac4415e2cf21", "external_organization": "12345"}}```

## Checklist
* [ ] `pre-commit run -a` passes
* [ ] updated documentation wherever necessary
* [ ] added or modified tests if necessary
* [ ] updated schemas and validators in [insights-data-schemas](https://github.com/RedHatInsights/insights-data-schemas) in case of input/output change
