### PR TITLE
Add deploy files for internal data pipelines related services [archive-sync-ols, mutiplexor] 

### DIFF
--- a/deploy/archive-sync-ols.yaml
+++ b/deploy/archive-sync-ols.yaml
@@ -153,7 +153,7 @@ objects:
         format: insights.formats._json.JsonFormat
         target_components: []
         consumer:
-          name: ccx_messaging.consumers.kafka_consumer.KafkaConsumer
+          name: ccx_messaging.consumers.decoded_ingress_consumer.DecodedIngressConsumer
           kwargs:
             incoming_topic: ${KAFKA_INCOMING_TOPIC}
             group.id: ${KAFKA_GROUP_ID}

--- a/deploy/archive-sync-ols.yaml
+++ b/deploy/archive-sync-ols.yaml
@@ -47,24 +47,6 @@ objects:
             - name: CLOWDER_ENABLED
               value: ${CLOWDER_ENABLED}
 
-            # Kafka configuration
-            - name: KAFKA_GROUP_ID
-              value: ${KAFKA_GROUP_ID}
-            - name: KAFKA_PLATFORM_SERVICE
-              value: ${KAFKA_PLATFORM_SERVICE}
-            - name: KAFKA_CONSUMER_SERVER
-              value: ${KAFKA_SERVER}
-            - name: KAFKA_CONSUMER_SECURITY_PROTOCOL
-              value: ${KAFKA_SECURITY_PROTOCOL}
-            - name: KAFKA_CONSUMER_SASL_MECHANISM
-              value: ${KAFKA_SASL_MECHANISM}
-            - name: KAFKA_INCOMING_TOPIC
-              value: ${KAFKA_INCOMING_TOPIC}
-
-            # S3 Configuration: secrets are populated by Clowder
-            - name: TARGET_S3_BUCKET
-              value: ${TARGET_S3_BUCKET}
-
             # TODO: Configure Sentry when the PoC is done
             # - name: SENTRY_DSN
             #   valueFrom:
@@ -281,10 +263,6 @@ parameters:
 - description: Service name for filtering received Kafka message from announce topic
   name: KAFKA_PLATFORM_SERVICE
   value: openshift
-- name: KAFKA_SECURITY_PROTOCOL
-  value: SASL_SSL
-- name: KAFKA_SASL_MECHANISM
-  value: SCRAM-SHA-512
 
 - name: TARGET_S3_BUCKET
   value: ccx-bucket-ols

--- a/deploy/archive-sync-ols.yaml
+++ b/deploy/archive-sync-ols.yaml
@@ -158,7 +158,6 @@ objects:
           name: ccx_messaging.consumers.kafka_consumer.KafkaConsumer
           kwargs:
             incoming_topic: ${KAFKA_INCOMING_TOPIC}
-            platform_service: ${KAFKA_PLATFORM_SERVICE}
             group.id: ${KAFKA_GROUP_ID}
             bootstrap.servers: ${KAFKA_SERVER}
             processing_timeout_s: 0
@@ -260,9 +259,6 @@ parameters:
 - name: KAFKA_SERVER
   description: App-SRE Kafka
   value: mq-kafka:29092
-- description: Service name for filtering received Kafka message from announce topic
-  name: KAFKA_PLATFORM_SERVICE
-  value: openshift
 
 - name: TARGET_S3_BUCKET
   value: ccx-bucket-ols

--- a/deploy/archive-sync-ols.yaml
+++ b/deploy/archive-sync-ols.yaml
@@ -56,8 +56,6 @@ objects:
             #       optional: true
             # - name: SENTRY_ENVIRONMENT
             #   value: ${ENV_NAME}
-            - name: ALLOW_UNSAFE_LINKS
-              value: ${ALLOW_UNSAFE_LINKS}
             - name: LOGGING_TO_CW_ENABLED
               value: "True"
             - name: CW_STREAM_NAME

--- a/deploy/archive-sync-ols.yaml
+++ b/deploy/archive-sync-ols.yaml
@@ -1,0 +1,319 @@
+---
+apiVersion: v1
+kind: Template
+metadata:
+  name: archive-sync-ols
+objects:
+
+- kind: HorizontalPodAutoscaler
+  apiVersion: autoscaling/v1
+  metadata:
+    labels:
+      app: ccx-data-pipeline
+    name: archive-sync-ols
+  spec:
+    minReplicas: ${{MIN_REPLICAS}}
+    maxReplicas: ${{MAX_REPLICAS}}
+    scaleTargetRef:
+      apiVersion: apps/v1
+      kind: Deployment
+      name: archive-sync-ols-instance
+    targetCPUUtilizationPercentage: 50
+
+- apiVersion: cloud.redhat.com/v1alpha1
+  kind: ClowdApp
+  metadata:
+    name: archive-sync-ols
+  spec:
+    envName: ${ENV_NAME}
+    objectStore:
+      - ${TARGET_S3_BUCKET}
+#    testing:
+#      iqePlugin: ccx
+    deployments:
+      - name: instance
+        webServices:
+          public:
+            enabled: false
+          private:
+            enabled: false
+          metrics:
+            enabled: true
+        podSpec:
+          image: ${IMAGE}:${IMAGE_TAG}
+          command: ["ccx-messaging"]
+          args: ["/data/config.yaml"]
+          env:
+            - name: CLOWDER_ENABLED
+              value: ${CLOWDER_ENABLED}
+
+            # Kafka configuration
+            - name: KAFKA_GROUP_ID
+              value: ${KAFKA_GROUP_ID}
+            - name: KAFKA_PLATFORM_SERVICE
+              value: ${KAFKA_PLATFORM_SERVICE}
+            - name: KAFKA_CONSUMER_SERVER
+              value: ${KAFKA_SERVER}
+            - name: KAFKA_CONSUMER_SECURITY_PROTOCOL
+              value: ${KAFKA_SECURITY_PROTOCOL}
+            - name: KAFKA_CONSUMER_SASL_MECHANISM
+              value: ${KAFKA_SASL_MECHANISM}
+            - name: KAFKA_INCOMING_TOPIC
+              value: ${KAFKA_INCOMING_TOPIC}
+
+            # S3 Configuration: secrets are populated by Clowder
+            - name: TARGET_S3_BUCKET
+              value: ${TARGET_S3_BUCKET}
+
+            # TODO: Configure Sentry when the PoC is done
+            # - name: SENTRY_DSN
+            #   valueFrom:
+            #     secretKeyRef:
+            #       key: dsn
+            #       name: archive-sync-ols-dsn
+            #       optional: true
+            # - name: SENTRY_ENVIRONMENT
+            #   value: ${ENV_NAME}
+            - name: ALLOW_UNSAFE_LINKS
+              value: ${ALLOW_UNSAFE_LINKS}
+            - name: LOGGING_TO_CW_ENABLED
+              value: "True"
+            - name: CW_STREAM_NAME
+              value: ${CW_LOG_STREAM}
+            - name: AWS_REGION_NAME
+              valueFrom:
+                secretKeyRef:
+                  name: cloudwatch
+                  key: aws_region
+                  optional: true
+            - name: CW_LOG_GROUP
+              valueFrom:
+                secretKeyRef:
+                  name: cloudwatch
+                  key: log_group_name
+                  optional: true
+            - name: CW_AWS_ACCESS_KEY_ID
+              valueFrom:
+                secretKeyRef:
+                  name: cloudwatch
+                  key: aws_access_key_id
+                  optional: true
+            - name: CW_AWS_SECRET_ACCESS_KEY
+              valueFrom:
+                secretKeyRef:
+                  name: cloudwatch
+                  key: aws_secret_access_key
+                  optional: true
+            - name: PYTHONUNBUFFERED
+              value: "1"
+          readinessProbe:
+            httpGet:
+              path: /metrics
+              port: 8000
+              scheme: HTTP
+            initialDelaySeconds: 20
+            successThreshold: 1
+            periodSeconds: 10
+            timeoutSeconds: 10
+          livenessProbe:
+            httpGet:
+              path: /metrics
+              port: 8000
+              scheme: HTTP
+            initialDelaySeconds: 20
+            successThreshold: 1
+            failureThreshold: 1
+            periodSeconds: 10
+            timeoutSeconds: 10
+          startupProbe:
+            httpGet:
+              path: /metrics
+              port: 8000
+              scheme: HTTP
+            initialDelaySeconds: 20
+            successThreshold: 1
+            # Wait for 10x10 seconds
+            failureThreshold: 10
+            periodSeconds: 10
+            timeoutSeconds: 10
+          volumeMounts:
+            - mountPath: /data
+              name: archive-sync-ols-config
+          volumes:
+            - configMap:
+                name: archive-sync-ols-config-map
+              name: archive-sync-ols-config
+          resources:
+            requests:
+              cpu: ${CPU_REQUEST}
+              memory: ${MEMORY_REQUEST}
+            limits:
+              cpu: ${CPU_LIMIT}
+              memory: ${MEMORY_LIMIT}
+
+    kafkaTopics:
+      - topicName: ${KAFKA_INCOMING_TOPIC}
+      - topicName: ${PAYLOAD_TRACKER_TOPIC}
+        partitions: 1
+
+- kind: ConfigMap
+  apiVersion: v1
+  metadata:
+    labels:
+      app: archive-sync-ols
+    name: archive-sync-ols-config-map
+  data:
+    config.yaml: |-
+      plugins:
+        packages:
+        - ccx_messaging
+      service:
+        extract_timeout:
+        extract_tmp_dir:
+        format: insights.formats._json.JsonFormat
+        target_components: []
+        consumer:
+          name: ccx_messaging.consumers.kafka_consumer.KafkaConsumer
+          kwargs:
+            incoming_topic: ${KAFKA_INCOMING_TOPIC}
+            platform_service: ${KAFKA_PLATFORM_SERVICE}
+            group.id: ${KAFKA_GROUP_ID}
+            bootstrap.servers: ${KAFKA_SERVER}
+            processing_timeout_s: 0
+            max.poll.interval.ms: 600000
+            heartbeat.interval.ms: 10000
+            session.timeout.ms: 20000
+        downloader:
+          name: ccx_messaging.downloaders.http_downloader.HTTPDownloader
+          kwargs:
+            allow_unsafe_links: ${ALLOW_UNSAFE_LINKS}
+        engine:
+          name: ccx_messaging.engines.s3_upload_engine.S3UploadEngine
+          kwargs:
+            dest_bucket: ${TARGET_S3_BUCKET}
+            archives_path_prefix: archives/compressed
+        publisher:
+          name: insights_messaging.publishers.Publisher
+        watchers:
+          - name: ccx_messaging.watchers.stats_watcher.StatsWatcher
+            kwargs:
+              prometheus_port: 8000
+          - name: ccx_messaging.watchers.payload_tracker_watcher.PayloadTrackerWatcher
+            kwargs:
+              bootstrap.servers: ${KAFKA_SERVER}
+              topic: ${PAYLOAD_TRACKER_TOPIC}
+        logging:
+          version: 1
+          disable_existing_loggers: false
+          handlers:
+            default:
+              level: ${LOGLEVEL_STDOUT}
+              class: logging.StreamHandler
+              stream: ext://sys.stdout
+              formatter: default
+          formatters:
+            default:
+              format: '%(asctime)s %(name)s %(levelname)-8s %(message)s'
+              datefmt: '%Y-%m-%d %H:%M:%S'
+          root:
+            level: ${LOGLEVEL_ROOT}
+            handlers:
+              - default
+          loggers:
+            ccx_messaging:
+              level: ${LOGLEVEL_CCX_MESSAGING}
+            insights_messaging:
+              level: ${LOGLEVEL_INSIGHTS_MESSAGING}
+            insights:
+              level: ${LOGLEVEL_INSIGHTS}
+            kafka:
+              level: ${LOGLEVEL_KAFKA}
+
+- kind: Service
+  apiVersion: v1
+  metadata:
+    annotations:
+      prometheus.io/path: /metrics
+      prometheus.io/port: "8000"
+      prometheus.io/scheme: http
+      prometheus.io/scrape: "true"
+    name: archive-sync-ols-prometheus-exporter
+    labels:
+      app: archive-sync-ols
+  spec:
+    ports:
+      - name: archive-sync-ols-port-metrics
+        port: 8000
+        protocol: TCP
+        targetPort: 8000
+    selector:
+      app: archive-sync-ols
+
+parameters:
+- description: Image name
+  name: IMAGE
+  value: quay.io/cloudservices/ccx-messaging
+- description: Image tag
+  name: IMAGE_TAG
+  required: true
+- description: Determines Clowder deployment
+  name: CLOWDER_ENABLED
+  value: "true"
+- description: ClowdEnv Name
+  name: ENV_NAME
+  required: true
+- description: Minimum number of pods to use when autoscaling is enabled
+  name: MIN_REPLICAS
+  value: '1'
+- description: Maximum number of pods to use when autoscaling is enabled
+  name: MAX_REPLICAS
+  value: '8'
+
+- name: KAFKA_INCOMING_TOPIC
+  value: ccx.new.archive.ols
+- name: PAYLOAD_TRACKER_TOPIC
+  value: platform.payload-status
+- name: KAFKA_GROUP_ID
+  value: archive_sync_ols_app
+- name: KAFKA_SERVER
+  description: App-SRE Kafka
+  value: mq-kafka:29092
+- description: Service name for filtering received Kafka message from announce topic
+  name: KAFKA_PLATFORM_SERVICE
+  value: openshift
+- name: KAFKA_SECURITY_PROTOCOL
+  value: SASL_SSL
+- name: KAFKA_SASL_MECHANISM
+  value: SCRAM-SHA-512
+
+- name: TARGET_S3_BUCKET
+  value: ccx-bucket-ols
+
+- name: CLOUDWATCH_DEBUG
+  value: "false"
+- name: CW_LOG_STREAM
+  value: "archive-sync-ols"
+- name: ALLOW_UNSAFE_LINKS
+  value: ""
+
+- name: CPU_LIMIT
+  value: 200m
+- name: MEMORY_LIMIT
+  value: 512Mi
+- name: CPU_REQUEST
+  value: 100m
+- name: MEMORY_REQUEST
+  value: 256Mi
+
+- name: LOGLEVEL_CCX_MESSAGING
+  value: DEBUG
+- name: LOGLEVEL_INSIGHTS_MESSAGING
+  value: DEBUG
+- name: LOGLEVEL_INSIGHTS
+  value: WARNING
+- name: LOGLEVEL_KAFKA
+  value: INFO
+- name: LOGLEVEL_STDOUT
+  value: DEBUG
+- name: LOGLEVEL_ROOT
+  value: WARNING

--- a/deploy/multiplexor.yaml
+++ b/deploy/multiplexor.yaml
@@ -47,24 +47,6 @@ objects:
             - name: CLOWDER_ENABLED
               value: ${CLOWDER_ENABLED}
 
-            # Kafka configuration
-            - name: KAFKA_GROUP_ID
-              value: ${KAFKA_GROUP_ID}
-            - name: KAFKA_PLATFORM_SERVICE
-              value: ${KAFKA_PLATFORM_SERVICE}
-            - name: KAFKA_CONSUMER_SERVER
-              value: ${KAFKA_SERVER}
-            - name: KAFKA_CONSUMER_SECURITY_PROTOCOL
-              value: ${KAFKA_SECURITY_PROTOCOL}
-            - name: KAFKA_CONSUMER_SASL_MECHANISM
-              value: ${KAFKA_SASL_MECHANISM}
-            - name: KAFKA_INCOMING_TOPIC
-              value: ${KAFKA_INCOMING_TOPIC}
-
-            # S3 Configuration: secrets are populated by Clowder
-            - name: TARGET_S3_BUCKET
-              value: ${TARGET_S3_BUCKET}
-
             # TODO: Configure Sentry when the PoC is done
             # - name: SENTRY_DSN
             #   valueFrom:
@@ -292,10 +274,6 @@ parameters:
 - description: Service name for filtering received Kafka message from announce topic
   name: KAFKA_PLATFORM_SERVICE
   value: openshift
-- name: KAFKA_SECURITY_PROTOCOL
-  value: SASL_SSL
-- name: KAFKA_SASL_MECHANISM
-  value: SCRAM-SHA-512
 
 - name: CLOUDWATCH_DEBUG
   value: "false"

--- a/deploy/multiplexor.yaml
+++ b/deploy/multiplexor.yaml
@@ -56,8 +56,6 @@ objects:
             #       optional: true
             # - name: SENTRY_ENVIRONMENT
             #   value: ${ENV_NAME}
-            - name: ALLOW_UNSAFE_LINKS
-              value: ${ALLOW_UNSAFE_LINKS}
             - name: LOGGING_TO_CW_ENABLED
               value: "True"
             - name: CW_STREAM_NAME

--- a/deploy/multiplexor.yaml
+++ b/deploy/multiplexor.yaml
@@ -1,0 +1,325 @@
+---
+apiVersion: v1
+kind: Template
+metadata:
+  name: multiplexor
+objects:
+
+- kind: HorizontalPodAutoscaler
+  apiVersion: autoscaling/v1
+  metadata:
+    labels:
+      app: ccx-data-pipeline
+    name: multiplexor
+  spec:
+    minReplicas: ${{MIN_REPLICAS}}
+    maxReplicas: ${{MAX_REPLICAS}}
+    scaleTargetRef:
+      apiVersion: apps/v1
+      kind: Deployment
+      name: multiplexor-instance
+    targetCPUUtilizationPercentage: 50
+
+- apiVersion: cloud.redhat.com/v1alpha1
+  kind: ClowdApp
+  metadata:
+    name: multiplexor
+  spec:
+    envName: ${ENV_NAME}
+#    testing:
+#      iqePlugin: ccx
+    deployments:
+      - name: instance
+        webServices:
+          public:
+            enabled: false
+          private:
+            enabled: false
+          metrics:
+            enabled: true
+        podSpec:
+          image: ${IMAGE}:${IMAGE_TAG}
+          command: ["ccx-messaging"]
+          args: ["/data/config.yaml"]
+          env:
+            - name: CLOWDER_ENABLED
+              value: ${CLOWDER_ENABLED}
+
+            # Kafka configuration
+            - name: KAFKA_GROUP_ID
+              value: ${KAFKA_GROUP_ID}
+            - name: KAFKA_PLATFORM_SERVICE
+              value: ${KAFKA_PLATFORM_SERVICE}
+            - name: KAFKA_CONSUMER_SERVER
+              value: ${KAFKA_SERVER}
+            - name: KAFKA_CONSUMER_SECURITY_PROTOCOL
+              value: ${KAFKA_SECURITY_PROTOCOL}
+            - name: KAFKA_CONSUMER_SASL_MECHANISM
+              value: ${KAFKA_SASL_MECHANISM}
+            - name: KAFKA_INCOMING_TOPIC
+              value: ${KAFKA_INCOMING_TOPIC}
+
+            # S3 Configuration: secrets are populated by Clowder
+            - name: TARGET_S3_BUCKET
+              value: ${TARGET_S3_BUCKET}
+
+            # TODO: Configure Sentry when the PoC is done
+            # - name: SENTRY_DSN
+            #   valueFrom:
+            #     secretKeyRef:
+            #       key: dsn
+            #       name: multiplexor-dsn
+            #       optional: true
+            # - name: SENTRY_ENVIRONMENT
+            #   value: ${ENV_NAME}
+            - name: ALLOW_UNSAFE_LINKS
+              value: ${ALLOW_UNSAFE_LINKS}
+            - name: LOGGING_TO_CW_ENABLED
+              value: "True"
+            - name: CW_STREAM_NAME
+              value: ${CW_LOG_STREAM}
+            - name: AWS_REGION_NAME
+              valueFrom:
+                secretKeyRef:
+                  name: cloudwatch
+                  key: aws_region
+                  optional: true
+            - name: CW_LOG_GROUP
+              valueFrom:
+                secretKeyRef:
+                  name: cloudwatch
+                  key: log_group_name
+                  optional: true
+            - name: CW_AWS_ACCESS_KEY_ID
+              valueFrom:
+                secretKeyRef:
+                  name: cloudwatch
+                  key: aws_access_key_id
+                  optional: true
+            - name: CW_AWS_SECRET_ACCESS_KEY
+              valueFrom:
+                secretKeyRef:
+                  name: cloudwatch
+                  key: aws_secret_access_key
+                  optional: true
+            - name: PYTHONUNBUFFERED
+              value: "1"
+          readinessProbe:
+            httpGet:
+              path: /metrics
+              port: 8000
+              scheme: HTTP
+            initialDelaySeconds: 20
+            successThreshold: 1
+            periodSeconds: 10
+            timeoutSeconds: 10
+          livenessProbe:
+            httpGet:
+              path: /metrics
+              port: 8000
+              scheme: HTTP
+            initialDelaySeconds: 20
+            successThreshold: 1
+            failureThreshold: 1
+            periodSeconds: 10
+            timeoutSeconds: 10
+          startupProbe:
+            httpGet:
+              path: /metrics
+              port: 8000
+              scheme: HTTP
+            initialDelaySeconds: 20
+            successThreshold: 1
+            # Wait for 10x10 seconds
+            failureThreshold: 10
+            periodSeconds: 10
+            timeoutSeconds: 10
+          volumeMounts:
+            - mountPath: /data
+              name: multiplexor-config
+          volumes:
+            - configMap:
+                name: multiplexor-config-map
+              name: multiplexor-config
+          resources:
+            requests:
+              cpu: ${CPU_REQUEST}
+              memory: ${MEMORY_REQUEST}
+            limits:
+              cpu: ${CPU_LIMIT}
+              memory: ${MEMORY_LIMIT}
+
+    kafkaTopics:
+      - topicName: ${KAFKA_INCOMING_TOPIC}
+      - topicName: ${PAYLOAD_TRACKER_TOPIC}
+        partitions: 1
+      - topicName: ${KAFKA_OUTGOING_TOPIC_IO}
+      - topicName: ${KAFKA_OUTGOING_TOPIC_OLS}
+
+- kind: ConfigMap
+  apiVersion: v1
+  metadata:
+    labels:
+      app: multiplexor
+    name: multiplexor-config-map
+  data:
+    config.yaml: |-
+      plugins:
+        packages:
+        - ccx_messaging
+      service:
+        extract_timeout:
+        extract_tmp_dir:
+        format: insights.formats._json.JsonFormat
+        target_components: []
+        consumer:
+          name: ccx_messaging.consumers.kafka_consumer.KafkaConsumer
+          kwargs:
+            incoming_topic: ${KAFKA_INCOMING_TOPIC}
+            platform_service: ${KAFKA_PLATFORM_SERVICE}
+            group.id: ${KAFKA_GROUP_ID}
+            bootstrap.servers: ${KAFKA_SERVER}
+            processing_timeout_s: 0
+            max.poll.interval.ms: 600000
+            heartbeat.interval.ms: 10000
+            session.timeout.ms: 20000
+        downloader:
+          name: ccx_messaging.downloaders.http_downloader.HTTPDownloader
+          kwargs:
+            allow_unsafe_links: ${ALLOW_UNSAFE_LINKS}
+        engine:
+          name: ccx_messaging.engines.multiplexor_engine.MultiplexorEngine
+          kwargs:
+            filters:
+              openshift_lightspeed.json: OLS
+        publisher:
+          name: ccx_messaging.publishers.multiplexor_kafka_publisher.MultiplexorPublisher
+          kwargs:
+            bootstrap.servers: ${KAFKA_SERVER}
+            outgoing_topics:
+              OLS: ${KAFKA_OUTGOING_TOPIC_OLS}
+              DEFAULT: ${KAFKA_OUTGOING_TOPIC_IO}
+        watchers:
+          - name: ccx_messaging.watchers.stats_watcher.StatsWatcher
+            kwargs:
+              prometheus_port: 8000
+          - name: ccx_messaging.watchers.payload_tracker_watcher.PayloadTrackerWatcher
+            kwargs:
+              bootstrap.servers: ${KAFKA_SERVER}
+              topic: ${PAYLOAD_TRACKER_TOPIC}
+        logging:
+          version: 1
+          disable_existing_loggers: false
+          handlers:
+            default:
+              level: ${LOGLEVEL_STDOUT}
+              class: logging.StreamHandler
+              stream: ext://sys.stdout
+              formatter: default
+          formatters:
+            default:
+              format: '%(asctime)s %(name)s %(levelname)-8s %(message)s'
+              datefmt: '%Y-%m-%d %H:%M:%S'
+          root:
+            level: ${LOGLEVEL_ROOT}
+            handlers:
+              - default
+          loggers:
+            ccx_messaging:
+              level: ${LOGLEVEL_CCX_MESSAGING}
+            insights_messaging:
+              level: ${LOGLEVEL_INSIGHTS_MESSAGING}
+            insights:
+              level: ${LOGLEVEL_INSIGHTS}
+            kafka:
+              level: ${LOGLEVEL_KAFKA}
+
+- kind: Service
+  apiVersion: v1
+  metadata:
+    annotations:
+      prometheus.io/path: /metrics
+      prometheus.io/port: "8000"
+      prometheus.io/scheme: http
+      prometheus.io/scrape: "true"
+    name: multiplexor-prometheus-exporter
+    labels:
+      app: multiplexor
+  spec:
+    ports:
+      - name: multiplexor-port-metrics
+        port: 8000
+        protocol: TCP
+        targetPort: 8000
+    selector:
+      app: multiplexor
+
+parameters:
+- description: Image name
+  name: IMAGE
+  value: quay.io/cloudservices/ccx-messaging
+- description: Image tag
+  name: IMAGE_TAG
+  required: true
+- description: Determines Clowder deployment
+  name: CLOWDER_ENABLED
+  value: "true"
+- description: ClowdEnv Name
+  name: ENV_NAME
+  required: true
+- description: Minimum number of pods to use when autoscaling is enabled
+  name: MIN_REPLICAS
+  value: '1'
+- description: Maximum number of pods to use when autoscaling is enabled
+  name: MAX_REPLICAS
+  value: '8'
+
+- name: KAFKA_INCOMING_TOPIC
+  value: platform.upload.announce
+- name: KAFKA_OUTGOING_TOPIC_IO
+  value: ccx.new.archive.io
+- name: KAFKA_OUTGOING_TOPIC_OLS
+  value: ccx.new.archive.ols
+- name: PAYLOAD_TRACKER_TOPIC
+  value: platform.payload-status
+- name: KAFKA_GROUP_ID
+  value: multiplexor_app
+- name: KAFKA_SERVER
+  description: App-SRE Kafka
+  value: mq-kafka:29092
+- description: Service name for filtering received Kafka message from announce topic
+  name: KAFKA_PLATFORM_SERVICE
+  value: openshift
+- name: KAFKA_SECURITY_PROTOCOL
+  value: SASL_SSL
+- name: KAFKA_SASL_MECHANISM
+  value: SCRAM-SHA-512
+
+- name: CLOUDWATCH_DEBUG
+  value: "false"
+- name: CW_LOG_STREAM
+  value: "multiplexor"
+- name: ALLOW_UNSAFE_LINKS
+  value: ""
+
+- name: CPU_LIMIT
+  value: 200m
+- name: MEMORY_LIMIT
+  value: 512Mi
+- name: CPU_REQUEST
+  value: 100m
+- name: MEMORY_REQUEST
+  value: 256Mi
+
+- name: LOGLEVEL_CCX_MESSAGING
+  value: DEBUG
+- name: LOGLEVEL_INSIGHTS_MESSAGING
+  value: DEBUG
+- name: LOGLEVEL_INSIGHTS
+  value: WARNING
+- name: LOGLEVEL_KAFKA
+  value: INFO
+- name: LOGLEVEL_STDOUT
+  value: DEBUG
+- name: LOGLEVEL_ROOT
+  value: WARNING

--- a/deploy/multiplexor.yaml
+++ b/deploy/multiplexor.yaml
@@ -28,6 +28,8 @@ objects:
     envName: ${ENV_NAME}
 #    testing:
 #      iqePlugin: ccx
+    dependencies:
+      - ingress
     deployments:
       - name: instance
         webServices:


### PR DESCRIPTION
# Description

Clowdapp definitions for multiplexor and archive-syn-ols

Related to CCXDEV-14674

## Type of change

- New feature (non-breaking change which adds functionality)

## Testing steps


To deploy the services on ephemeral:

```
bonfire deploy ccx-data-pipeline --ref-env insights-production --frontends false  --namespace $ns -c bonfire.deploy.yaml --component ccx-data-pipeline --component dvo-extractor --component ccx-insights-results --timeout 60
```

with `bonfire.deploy.yaml` as:

```
apps:
- name: ccx-data-pipeline
  components:
  - name: ccx-data-pipeline
    host: github
    repo: RedHatInsights/insights-ccx-messaging
    path: /deploy/archive-sync.yaml
    ref: main
    parameters:
      IMAGE: quay.io/redhat-user-workloads/obsint-processing-tenant/ccx-messaging/ccx-messaging
      IMAGE_TAG: 478a118385393f11e7454c258c8b0bbdef4bd7a9
      MAX_REPLICAS: 4
      ALLOW_UNSAFE_LINKS: "True"
  - name: dvo-extractor
    host: github
    repo: ikerreyes/insights-ccx-messaging
    path: /deploy/archive-sync-ols.yaml
    ref: CCXDEV-14674-2
    parameters:
      IMAGE: quay.io/redhat-user-workloads/obsint-processing-tenant/ccx-messaging/ccx-messaging
      IMAGE_TAG: 478a118385393f11e7454c258c8b0bbdef4bd7a9
      MAX_REPLICAS: 4
      ALLOW_UNSAFE_LINKS: "True"
  - name: ccx-insights-results
    host: github
    repo: ikerreyes/insights-ccx-messaging
    path: /deploy/multiplexor.yaml
    ref: CCXDEV-14674-2
    parameters:
      IMAGE: quay.io/redhat-user-workloads/obsint-processing-tenant/ccx-messaging/ccx-messaging
      IMAGE_TAG: 478a118385393f11e7454c258c8b0bbdef4bd7a9
      MAX_REPLICAS: 4
      ALLOW_UNSAFE_LINKS: "True"
```


## Checklist
* [ ] `pre-commit run -a` passes
* [ ] updated documentation wherever necessary
* [ ] added or modified tests if necessary
* [ ] updated schemas and validators in [insights-data-schemas](https://github.com/RedHatInsights/insights-data-schemas) in case of input/output change
