### PR TITLE
Update ephemeral HTTP regex

### DIFF
--- a/ccx_messaging/downloaders/http_downloader.py
+++ b/ccx_messaging/downloaders/http_downloader.py
@@ -66,7 +66,8 @@ class HTTPDownloader:
     HTTP_RE = re.compile(
         r"^(?:https://[^/]+\.s3\.amazonaws\.com/[0-9a-zA-Z/\-]+|"
         r"https://s3\.[0-9a-zA-Z\-]+\.amazonaws\.com/[0-9a-zA-Z\-]+/[0-9a-zA-Z/\-]+|"
-        r"http://minio:9000/insights-upload-perma/[0-9a-zA-Z\.\-]+/[0-9a-zA-Z\-]+)\?"
+        r"http://(minio|env-ephemeral-(?P<name>[0-9a-zA-Z\-]+)-minio.ephemeral-(?P=name)+.svc):9000/"
+        r"insights-upload-perma/[0-9a-zA-Z\.\-]+/[0-9a-zA-Z\-]+)\?"
         r"X-Amz-Algorithm=AWS4-HMAC-SHA256&X-Amz-Credential=[^/]+$"
     )
 


### PR DESCRIPTION
# Description

Cover ephemeral cases for URLs of the form `http://env-ephemeral-mkx7cz-minio.ephemeral-mkx7cz.svc:9000/insights-upload-perma/ingress-service-6d5f997dd4-ckkwp/...`

Related to [CCXDEV-14674](https://issues.redhat.com/browse/CCXDEV-14674)

## Type of change

Please delete options that are not relevant.

- Bug fix (non-breaking change which fixes an issue)

## Testing steps

## Checklist
* [ ] `pre-commit run -a` passes
* [ ] updated documentation wherever necessary
* [ ] added or modified tests if necessary
* [ ] updated schemas and validators in [insights-data-schemas](https://github.com/RedHatInsights/insights-data-schemas) in case of input/output change
