### PR TITLE
Remove unused env var for archive-sync clowdapp

### DIFF
--- a/deploy/archive-sync.yaml
+++ b/deploy/archive-sync.yaml
@@ -263,9 +263,6 @@ parameters:
 - name: KAFKA_SERVER
   description: App-SRE Kafka
   value: mq-kafka:29092
-- description: Service name for filtering received Kafka message from announce topic
-  name: KAFKA_PLATFORM_SERVICE
-  value: openshift
 
 - name: TARGET_S3_BUCKET
   value: ccx-bucket

--- a/deploy/archive-sync.yaml
+++ b/deploy/archive-sync.yaml
@@ -47,24 +47,6 @@ objects:
             - name: CLOWDER_ENABLED
               value: ${CLOWDER_ENABLED}
 
-            # Kafka configuration
-            - name: KAFKA_GROUP_ID
-              value: ${KAFKA_GROUP_ID}
-            - name: KAFKA_PLATFORM_SERVICE
-              value: ${KAFKA_PLATFORM_SERVICE}
-            - name: KAFKA_CONSUMER_SERVER
-              value: ${KAFKA_SERVER}
-            - name: KAFKA_CONSUMER_SECURITY_PROTOCOL
-              value: ${KAFKA_SECURITY_PROTOCOL}
-            - name: KAFKA_CONSUMER_SASL_MECHANISM
-              value: ${KAFKA_SASL_MECHANISM}
-            - name: KAFKA_INCOMING_TOPIC
-              value: ${KAFKA_INCOMING_TOPIC}
-
-            # S3 Configuration: secrets are populated by Clowder
-            - name: TARGET_S3_BUCKET
-              value: ${TARGET_S3_BUCKET}
-
             # TODO: Configure Sentry when the PoC is done
             # - name: SENTRY_DSN
             #   valueFrom:
@@ -74,8 +56,6 @@ objects:
             #       optional: true
             # - name: SENTRY_ENVIRONMENT
             #   value: ${ENV_NAME}
-            - name: ALLOW_UNSAFE_LINKS
-              value: ${ALLOW_UNSAFE_LINKS}
             - name: LOGGING_TO_CW_ENABLED
               value: "True"
             - name: CW_STREAM_NAME
@@ -286,10 +266,6 @@ parameters:
 - description: Service name for filtering received Kafka message from announce topic
   name: KAFKA_PLATFORM_SERVICE
   value: openshift
-- name: KAFKA_SECURITY_PROTOCOL
-  value: SASL_SSL
-- name: KAFKA_SASL_MECHANISM
-  value: SCRAM-SHA-512
 
 - name: TARGET_S3_BUCKET
   value: ccx-bucket


### PR DESCRIPTION
# Description

There are a number of exposed env vars that are not neede for the app to work properly. Thus, we are dropping them.

In addition, dropping the platform service config option for the consumer as the messages from multiplexor do not include the header.

Related to [CCXDEV-14674](https://issues.redhat.com/browse/CCXDEV-14674)

## Type of change

Please delete options that are not relevant.

- Bug fix (non-breaking change which fixes an issue)

## Testing steps
 
Same as in https://github.com/RedHatInsights/insights-ccx-messaging/pull/437

## Checklist
* [ ] `pre-commit run -a` passes
* [ ] updated documentation wherever necessary
* [ ] added or modified tests if necessary
* [ ] updated schemas and validators in [insights-data-schemas](https://github.com/RedHatInsights/insights-data-schemas) in case of input/output change
