### PR TITLE
New consumer for messages from multiplexor

### DIFF
--- a/ccx_messaging/consumers/decoded_ingress_consumer.py
+++ b/ccx_messaging/consumers/decoded_ingress_consumer.py
@@ -13,7 +13,7 @@ from ccx_messaging.schemas import IDENTITY_SCHEMA
 LOG = logging.getLogger(__name__)
 
 
-class KafkaMultiplexorConsumer(KafkaConsumer):
+class DecodedIngressConsumer(KafkaConsumer):
     """Kafka consumer for decoded ingress messages produced by KafkaConsumer."""
 
     INPUT_MESSAGE_SCHEMA = {
@@ -33,7 +33,7 @@ class KafkaMultiplexorConsumer(KafkaConsumer):
         try:
             deserialized_message = json.loads(message)
             jsonschema.validate(
-                instance=deserialized_message, schema=KafkaMultiplexorConsumer.INPUT_MESSAGE_SCHEMA
+                instance=deserialized_message, schema=DecodedIngressConsumer.INPUT_MESSAGE_SCHEMA
             )
 
         except TypeError as ex:

--- a/ccx_messaging/consumers/multiplexor_consumer.py
+++ b/ccx_messaging/consumers/multiplexor_consumer.py
@@ -1,0 +1,79 @@
+"""Kafka consumer implementation for multiplexor messages using Confluent Kafka library."""
+
+import json
+import logging
+
+import jsonschema
+from confluent_kafka import Message
+
+from ccx_messaging.consumers.kafka_consumer import KafkaConsumer
+from ccx_messaging.error import CCXMessagingError
+from ccx_messaging.schemas import IDENTITY_SCHEMA
+
+LOG = logging.getLogger(__name__)
+
+
+class KafkaMultiplexorConsumer(KafkaConsumer):
+    """Kafka consumer for decoded ingress messages produced by KafkaConsumer."""
+
+    INPUT_MESSAGE_SCHEMA = {
+        "type": "object",
+        "properties": {
+            "url": {"type": "string"},
+            "identity": IDENTITY_SCHEMA,
+            "timestamp": {"type": "string"},
+            "cluster_name": {"type": ["string", "null"]},
+        },
+        "required": ["url", "identity", "timestamp"],
+    }
+
+    @staticmethod
+    def parse_decoded_ingress_message(message: bytes) -> dict:
+        """Parse a bytes messages into a dictionary, decoding encoded values."""
+        try:
+            deserialized_message = json.loads(message)
+            jsonschema.validate(
+                instance=deserialized_message, schema=KafkaMultiplexorConsumer.INPUT_MESSAGE_SCHEMA
+            )
+
+        except TypeError as ex:
+            LOG.warning("Incorrect message type: %s", message)
+            raise CCXMessagingError("Incorrect message type") from ex
+
+        except json.JSONDecodeError as ex:
+            LOG.warning("Unable to decode received message: %s", message)
+            raise CCXMessagingError("Unable to decode received message") from ex
+
+        except jsonschema.ValidationError as ex:
+            LOG.warning("Invalid input message JSON schema: %s", deserialized_message)
+            raise CCXMessagingError("Invalid input message JSON schema") from ex
+
+        LOG.debug("JSON schema validated: %s", deserialized_message)
+
+        return deserialized_message
+
+    def deserialize(self, msg: Message) -> dict:
+        """Deserialize the message received from Kafka into a dictionary."""
+        if not msg:
+            raise CCXMessagingError("No incoming message: %s", msg)
+
+        try:
+            value = msg.value()
+        except AttributeError as ex:
+            raise CCXMessagingError("Invalid incoming message type: %s", type(msg)) from ex
+
+        LOG.debug("Deserializing incoming message(%s): %s", self.log_pattern, value)
+
+        if not value:
+            raise CCXMessagingError("Unable to read incoming message: %s", value)
+
+        deserialized_msg = self.parse_decoded_ingress_message(value)
+        LOG.debug("JSON message deserialized (%s): %s", self.log_pattern, deserialized_msg)
+
+        if "cluster_name" not in deserialized_msg:
+            cluster_id = (
+                deserialized_msg.get("identity", {}).get("system", {}).get("cluster_id", None)
+            )
+            deserialized_msg["cluster_name"] = cluster_id
+
+        return deserialized_msg

--- a/deploy/archive-sync.yaml
+++ b/deploy/archive-sync.yaml
@@ -174,7 +174,7 @@ objects:
         format: insights.formats._json.JsonFormat
         target_components: []
         consumer:
-          name: ccx_messaging.consumers.multiplexor_consumer.KafkaMultiplexorConsumer
+          name: ccx_messaging.consumers.decoded_ingress_consumer.DecodedIngressConsumer
           kwargs:
             incoming_topic: ${KAFKA_INCOMING_TOPIC}
             group.id: ${KAFKA_GROUP_ID}

--- a/deploy/archive-sync.yaml
+++ b/deploy/archive-sync.yaml
@@ -174,7 +174,7 @@ objects:
         format: insights.formats._json.JsonFormat
         target_components: []
         consumer:
-          name: ccx_messaging.consumers.kafka_consumer.KafkaConsumer
+          name: ccx_messaging.consumers.multiplexor_consumer.KafkaMultiplexorConsumer
           kwargs:
             incoming_topic: ${KAFKA_INCOMING_TOPIC}
             platform_service: ${KAFKA_PLATFORM_SERVICE}

--- a/deploy/archive-sync.yaml
+++ b/deploy/archive-sync.yaml
@@ -177,7 +177,6 @@ objects:
           name: ccx_messaging.consumers.multiplexor_consumer.KafkaMultiplexorConsumer
           kwargs:
             incoming_topic: ${KAFKA_INCOMING_TOPIC}
-            platform_service: ${KAFKA_PLATFORM_SERVICE}
             group.id: ${KAFKA_GROUP_ID}
             bootstrap.servers: ${KAFKA_SERVER}
             processing_timeout_s: 0

--- a/test/consumers/decoded_ingress_consumer_test.py
+++ b/test/consumers/decoded_ingress_consumer_test.py
@@ -1,0 +1,168 @@
+# Copyright 2025 Red Hat, Inc
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Module containing unit tests for the `KafkaMultiplexorConsumer` class."""
+
+import datetime
+import json
+from unittest.mock import MagicMock, patch
+
+import pytest
+from freezegun import freeze_time
+
+from ccx_messaging.consumers.decoded_ingress_consumer import DecodedIngressConsumer
+from ccx_messaging.error import CCXMessagingError
+
+from . import KafkaMessage
+
+
+_INVALID_TYPE_VALUES = [
+    None,
+    42,
+    3.14,
+    True,
+    [],
+    {},
+]
+
+
+@pytest.mark.parametrize("value", _INVALID_TYPE_VALUES)
+@patch("ccx_messaging.consumers.kafka_consumer.ConfluentConsumer")
+def test_deserialize_invalid_type(mock_consumer, value):
+    """Test that passing invalid data type to `deserialize` raises an exception."""
+    sut = DecodedIngressConsumer(None, None, None, incoming_topic=None)
+    with pytest.raises(CCXMessagingError):
+        sut.deserialize(value)
+
+
+@pytest.mark.parametrize("value", _INVALID_TYPE_VALUES)
+@patch("ccx_messaging.consumers.kafka_consumer.ConfluentConsumer")
+def test_deserialize_invalid_type_as_kafka_message(mock_consumer, value):
+    """Test that passing invalid data type to `deserialize` raises an exception."""
+    sut = DecodedIngressConsumer(None, None, None, incoming_topic=None)
+    with pytest.raises(CCXMessagingError):
+        sut.deserialize(KafkaMessage(value))
+
+
+_INVALID_MESSAGES = [
+    "",
+    "{}",
+    '{"noturl":"https://s3.com/hash"}',
+    '{"url":"value"',
+    '"url":"value"}',
+    '"url":"value"',
+    '"{"url":"value"}"',
+    # incorrect identity
+    '{"url": "https://s3.com/hash", '
+    '"identity": {"external": {"internal": {"org_id": "12345678"}}}, '
+    '"timestamp": "2020-01-23T16:15:59.478901889Z"}',
+    '{"url": "https://s3.com/hash", '
+    '"identity": {"internal": {"internal": {"orgs": "12345678"}}}, '
+    '"timestamp": "2020-01-23T16:15:59.478901889Z"}',
+    # incorrect cluster_name
+    '{"url": "https://s3.com/hash", '
+    '"identity": {"identity": {"internal": {"org_id": "12345678"}}}, '
+    '"timestamp": "2020-01-23T16:15:59.478901889Z", '
+    '"cluster_name": 1}',
+]
+
+
+@pytest.mark.parametrize("msg", _INVALID_MESSAGES)
+@patch("ccx_messaging.consumers.kafka_consumer.ConfluentConsumer")
+def test_deserialize_invalid_format_str(mock_consumer, msg):
+    """Test that passing a malformed message to `deserialize` raises an exception."""
+    sut = DecodedIngressConsumer(None, None, None, None)
+    message = KafkaMessage(msg)
+    with pytest.raises(CCXMessagingError):
+        sut.deserialize(message)
+
+
+_VALID_MESSAGES = [
+    '{"url": "https://s3.com/hash", '
+    '"identity": {"identity": {"internal": {"org_id": "12345678"}}}, '
+    '"timestamp": "2020-01-23T16:15:59.478901889Z"}',
+    '{"url": "https://s3.com/hash", '
+    '"identity": {"identity": {"internal": {"org_id": "12345678"}}}, '
+    '"timestamp": "2020-01-23T16:15:59.478901889Z", '
+    '"cluster_name": "c9d116ce-93db-4c19-abe3-0de1d3554f99"}',
+    # null cluster
+    '{"url": "https://s3.com/hash", '
+    '"identity": {"identity": {"internal": {"org_id": "12345678"}}}, '
+    '"timestamp": "2020-01-23T16:15:59.478901889Z", '
+    '"cluster_name": null}',
+]
+
+
+@pytest.mark.parametrize("msg", _VALID_MESSAGES)
+@patch("ccx_messaging.consumers.kafka_consumer.ConfluentConsumer", lambda *a, **k: MagicMock())
+def test_deserialize_valid_str(msg):
+    """Test that proper string JSON input messages are correctly deserialized."""
+    sut = DecodedIngressConsumer(None, None, None, incoming_topic=None)
+    out = json.loads(msg)
+    if "cluster_name" not in msg:
+        out["cluster_name"] = None
+    assert sut.deserialize(KafkaMessage(msg)) == out
+
+
+@pytest.mark.parametrize("msg", _VALID_MESSAGES)
+@patch("ccx_messaging.consumers.kafka_consumer.ConfluentConsumer", lambda *a, **k: MagicMock())
+def test_deserialize_valid_bytes(msg):
+    """Test that proper string JSON input messages are correctly deserialized."""
+    sut = DecodedIngressConsumer(None, None, None, incoming_topic=None)
+    out = json.loads(msg)
+    if "cluster_name" not in msg:
+        out["cluster_name"] = None
+    assert sut.deserialize(KafkaMessage(msg.encode())) == out
+
+
+@pytest.mark.parametrize("msg", _VALID_MESSAGES)
+@patch("ccx_messaging.consumers.kafka_consumer.ConfluentConsumer", lambda *a, **k: MagicMock())
+def test_deserialize_valid_bytearray(msg):
+    """Test that proper string JSON input messages are correctly deserialized."""
+    sut = DecodedIngressConsumer(None, None, None, incoming_topic=None)
+    out = json.loads(msg)
+    if "cluster_name" not in msg:
+        out["cluster_name"] = None
+    assert sut.deserialize(KafkaMessage(bytearray(msg.encode()))) == out
+
+
+@pytest.mark.parametrize("msg", _VALID_MESSAGES)
+@patch("ccx_messaging.consumers.kafka_consumer.ConfluentConsumer", lambda *a, **k: MagicMock())
+def test_handles_valid(msg):
+    """Test that `handles` method returns True for valid messages."""
+    sut = DecodedIngressConsumer(None, None, None, incoming_topic=None)
+    assert sut.handles(KafkaMessage(msg))
+
+
+@patch("ccx_messaging.consumers.kafka_consumer.ConfluentConsumer", lambda *a, **k: MagicMock())
+@patch("ccx_messaging.consumers.kafka_consumer.KafkaConsumer.handles", lambda *a, **k: True)
+@patch("ccx_messaging.consumers.kafka_consumer.KafkaConsumer.fire", lambda *a, **k: None)
+def test_last_received_message_time_is_updated():
+    """Check that the variable last_received_message_time used by a Thread is correctly updated.
+
+    [CCXDEV-14812] the variable is never updated
+    """
+    t1 = datetime.datetime(2025, 1, 31, 12, 0, 0, tzinfo=datetime.timezone.utc)
+    t2 = datetime.datetime(2025, 1, 31, 12, 20, 0, tzinfo=datetime.timezone.utc)
+
+    with freeze_time(t1) as frozen_time:
+        sut = DecodedIngressConsumer(None, None, None, incoming_topic=None)
+        input_msg = KafkaMessage("{}")
+
+        frozen_time.move_to(t2)
+
+        with patch("ccx_messaging.consumers.kafka_consumer.KafkaConsumer.process", lambda: None):
+            sut.process_msg(input_msg)
+
+        assert sut.last_received_message_time == t2.timestamp()


### PR DESCRIPTION
# Description

Archive-sync and other consumers cannot processes multiplexor messages. Multiplexor messages, although similar to ingress one are not fully compatible with the ingress schema. Thus, we are adding a new consumer for those messages.

Fixes #CCXDEV-15016

A better solution has been proposed by @joselsegura :

> Right now `KafkaConsumer` extracts "cluster_name" and "identity" when deserializing the input_msg (`deserialize` method). Those keys are added to the input_msg, but they are only used in `create_broker` method.I suggest to:

  1. `parse_ingress_message` stops decoding the "b64_identity" field and keep it as it is, just checking that it exists  
  2. `deserialize` method only check and convert from bytes to dict using JSON and the Ingress schema, without adding nothing else
  3. The `create_broker` method uses `parse_identity` function to decode the "b64_identity" field **without adding nothing to input_msg**
  4. Inside the `create_broker`, use the identity, decoded from b64_identity, to add what is needed to the broker.


However, that solution requires an extensive refactoring, as some watcher like PayloadTracker and probably other components might be affected. In order to minimize breaking changes and to limit the scope of this change, we are introducing a new class to handle these messages.

## Type of change

- Bug fix (non-breaking change which fixes an issue)
- New feature (non-breaking change which adds functionality)

## Testing steps


To deploy the services on ephemeral:

```
bonfire deploy ccx-data-pipeline --ref-env insights-production --frontends false  --namespace $ns -c bonfire.deploy.yaml --component ccx-data-pipeline --component dvo-extractor --component ccx-insights-results --timeout 60
```

with `bonfire.deploy.yaml` as:

```
apps:
- name: ccx-data-pipeline
  components:
  - name: ccx-data-pipeline
    host: github
    repo: ikerreyes/insights-ccx-messaging
    path: /deploy/archive-sync.yaml
    ref: CCXDEV-15016
    parameters:
      IMAGE: quay.io/redhat-user-workloads/obsint-processing-tenant/ccx-messaging/ccx-messaging
      IMAGE_TAG: on-pr-898edbe843d0b14aac94830569b1d985d05dc96c
      MAX_REPLICAS: 4
      ALLOW_UNSAFE_LINKS: "True"
  - name: ccx-insights-results
    host: github
    repo: ikerreyes/insights-ccx-messaging
    path: /deploy/multiplexor.yaml
    ref: CCXDEV-14674-2
    parameters:
      IMAGE: quay.io/redhat-user-workloads/obsint-processing-tenant/ccx-messaging/ccx-messaging
      IMAGE_TAG: 4dd3ffe5a28dd6c1cb5b26e35a824f8abed93024
      MAX_REPLICAS: 4
      ALLOW_UNSAFE_LINKS: "True"
```

## Checklist
* [ ] `pre-commit run -a` passes
* [ ] updated documentation wherever necessary
* [ ] added or modified tests if necessary
* [ ] updated schemas and validators in [insights-data-schemas](https://github.com/RedHatInsights/insights-data-schemas) in case of input/output change
