### PR TITLE
Fixing bug in clowder _add_buckets_config

### DIFF
--- a/ccx_messaging/utils/clowder.py
+++ b/ccx_messaging/utils/clowder.py
@@ -135,10 +135,13 @@ def _update_bucket_config(bucket_name, configuration):
 
 def _add_buckets_config(config):
     # Handle engine config
-    engine_config = config.get("service", {}).get("engine", {}).get("kwargs", {})
-    _update_bucket_config(engine_config.get("dest_bucket"), engine_config)
+    engine = config.get("service", {}).get("engine", {})
+    if engine is not None:
+        engine_config = engine.get("kwargs", {})
+        _update_bucket_config(engine_config.get("dest_bucket"), engine_config)
 
-    # Handle s3downloader config
-    s3downloader_config = config.get("service", {}).get("downloader", {}).get("kwargs", {})
-    if s3downloader_config.get("name") == "ccx_messaging.downloaders.s3_downloader.S3Downloader":
+    # Handle downloader config
+    downloader = config.get("service", {}).get("downloader", {})
+    if downloader.get("name") == "ccx_messaging.downloaders.s3_downloader.S3Downloader":
+        s3downloader_config = downloader.get("kwargs", {})
         _update_bucket_config(s3downloader_config.get("bucket"), s3downloader_config)


### PR DESCRIPTION
# Description

There was a bug which caused _add_buckets_config function to ignore downloader configuration because the name of the downloader was expected in kwargs (which was bad approach because it is not in kwargs but as a dicrect value under downloader)

Fixes # (issue)

## Type of change

Please delete options that are not relevant.

- Bug fix (non-breaking change which fixes an issue)

## Testing steps

Please describe how the change was tested locally. If, for some reason, the testing was not done or not done fully, please describe what are the testing steps.

## Checklist
* [ ] `pre-commit run -a` passes
* [ ] updated documentation wherever necessary
* [ ] added or modified tests if necessary
* [ ] updated schemas and validators in [insights-data-schemas](https://github.com/RedHatInsights/insights-data-schemas) in case of input/output change
