### PR TITLE
Bug fix of _add_buckets_config function

### DIFF
--- a/ccx_messaging/utils/clowder.py
+++ b/ccx_messaging/utils/clowder.py
@@ -135,10 +135,13 @@ def _update_bucket_config(bucket_name, configuration):
 
 def _add_buckets_config(config):
     # Handle engine config
-    engine_config = config.get("service", {}).get("engine", {}).get("kwargs", {})
-    _update_bucket_config(engine_config.get("dest_bucket"), engine_config)
+    engine = config.get("service", {}).get("engine", {})
+    if engine.get("name") == "ccx_messaging.engines.s3_upload_engine.S3UploadEngine":
+        engine_config = engine.get("kwargs", {})
+        _update_bucket_config(engine_config.get("dest_bucket"), engine_config)
 
-    # Handle s3downloader config
-    s3downloader_config = config.get("service", {}).get("downloader", {}).get("kwargs", {})
-    if s3downloader_config.get("name") == "ccx_messaging.downloaders.s3_downloader.S3Downloader":
+    # Handle downloader config
+    downloader = config.get("service", {}).get("downloader", {})
+    if downloader.get("name") == "ccx_messaging.downloaders.s3_downloader.S3Downloader":
+        s3downloader_config = downloader.get("kwargs", {})
         _update_bucket_config(s3downloader_config.get("bucket"), s3downloader_config)


### PR DESCRIPTION
# Description

Fixing the bug in clowder.py _add_buckets_config function which was checking if the name for downloader if is in kwargs not directly under it. Also added check if the engine is avalible so deployment of pod does not fail when not.

Fixes # (issue)

## Type of change

- Bug fix (non-breaking change which fixes an issue)


## Testing steps

Tested in ephemeral with rules-processig instance

## Checklist
* [ ] `pre-commit run -a` passes
* [ ] updated documentation wherever necessary
* [ ] added or modified tests if necessary
* [ ] updated schemas and validators in [insights-data-schemas](https://github.com/RedHatInsights/insights-data-schemas) in case of input/output change
