### PR TITLE
Fixing s3_dowloader configuration from clowder

### DIFF
--- a/ccx_messaging/downloaders/s3_downloader.py
+++ b/ccx_messaging/downloaders/s3_downloader.py
@@ -28,20 +28,21 @@ class S3Downloader(ICMS3Downloader):
         """Set up the S3 downloader."""
         self.access_key = kwargs.get("access_key")
         self.secret_key = kwargs.get("secret_key")
-        self.endpoint_url = kwargs.get("endpoint_url")
+        # 'endpoint_url' key is legacy and retained for backward compatibility.
+        self.endpoint = kwargs.get("endpoint", kwargs.get("endpoint_url"))
         self.bucket = kwargs.get("bucket")
         if not self.access_key:
             raise CCXMessagingError("Access Key environment variable not set.")
         if not self.secret_key:
             raise CCXMessagingError("Secret Key environment variable not set.")
-        if not self.endpoint_url:
+        if not self.endpoint:
             raise CCXMessagingError("Endpoint environment variable not set.")
         if not self.bucket:
             raise CCXMessagingError("Bucket environment variable not set.")
         super().__init__(
             key=self.access_key,
             secret=self.secret_key,
-            client_kwargs={"endpoint_url": self.endpoint_url},
+            client_kwargs={"endpoint_url": self.endpoint},
         )
 
     @contextmanager


### PR DESCRIPTION
# Description

As the endpoint configuration is filled by clowder as `endpoint` i made changes so s3_downloader is able to be configured by clowder (if the `endpoint_url` is not in the kwargs it will try to get `endpoint`) and also this change wont break current deployment of rules-processing.

## Type of change


- Bug fix (non-breaking change which fixes an issue)
- New feature (non-breaking change which adds functionality)


## Checklist
* [ ] `pre-commit run -a` passes
* [ ] updated documentation wherever necessary
* [ ] added or modified tests if necessary
* [ ] updated schemas and validators in [insights-data-schemas](https://github.com/RedHatInsights/insights-data-schemas) in case of input/output change
