### PR TITLE
Adding request_id to publishers

### DIFF
--- a/ccx_messaging/publishers/idp_rule_processing_publisher.py
+++ b/ccx_messaging/publishers/idp_rule_processing_publisher.py
@@ -62,8 +62,9 @@ class IDPRuleProcessingPublisher(KafkaPublisher):
             "path": input_msg["path"],
             "metadata": input_msg["metadata"],
             "report": report,
+            "request_id": input_msg.get("request_id"),
         }
-        output_msg["RequestId"] = input_msg.get("request_id")
+
         message = json.dumps(output_msg)
         log.debug("Sending response to the %s topic.", self.topic)
         # Convert message string into a byte array.

--- a/ccx_messaging/publishers/idp_rule_processing_publisher.py
+++ b/ccx_messaging/publishers/idp_rule_processing_publisher.py
@@ -61,6 +61,7 @@ class IDPRuleProcessingPublisher(KafkaPublisher):
         output_msg = {
             "path": input_msg["path"],
             "metadata": input_msg["metadata"],
+            "request_id": input_msg.get("request_id"),
             "report": report,
         }
 

--- a/ccx_messaging/publishers/idp_rule_processing_publisher.py
+++ b/ccx_messaging/publishers/idp_rule_processing_publisher.py
@@ -61,10 +61,9 @@ class IDPRuleProcessingPublisher(KafkaPublisher):
         output_msg = {
             "path": input_msg["path"],
             "metadata": input_msg["metadata"],
-            "request_id": input_msg.get("request_id"),
             "report": report,
         }
-
+        output_msg["RequestId"] = input_msg.get("request_id")
         message = json.dumps(output_msg)
         log.debug("Sending response to the %s topic.", self.topic)
         # Convert message string into a byte array.

--- a/ccx_messaging/publishers/synced_archive_publisher.py
+++ b/ccx_messaging/publishers/synced_archive_publisher.py
@@ -29,6 +29,7 @@ class SyncedArchivePublisher(KafkaPublisher):
         """Publish response as Kafka message to outgoing topic."""
         output_msg = json.loads(report)
         output_msg.pop("reports", None)
+        output_msg["RequestId"] = input_msg.get("request_id")
         message = json.dumps(output_msg)
 
         LOG.debug("Sending response to the %s topic.", self.topic)

--- a/ccx_messaging/publishers/synced_archive_publisher.py
+++ b/ccx_messaging/publishers/synced_archive_publisher.py
@@ -29,7 +29,7 @@ class SyncedArchivePublisher(KafkaPublisher):
         """Publish response as Kafka message to outgoing topic."""
         output_msg = json.loads(report)
         output_msg.pop("reports", None)
-        output_msg["RequestId"] = input_msg.get("request_id")
+        output_msg["request_id"] = input_msg.get("request_id")
         message = json.dumps(output_msg)
 
         LOG.debug("Sending response to the %s topic.", self.topic)

--- a/test/publishers/idp_rule_processing_publisher_test.py
+++ b/test/publishers/idp_rule_processing_publisher_test.py
@@ -113,7 +113,7 @@ VALID_INPUT_MSG = [
             "report": {
                 "reports": [],
             },
-            "RequestId": "ingress-service-7777777777-q4444/4444444444-000001",
+            "request_id": "ingress-service-7777777777-q4444/4444444444-000001",
         },
         id="minimal valid",
     ),
@@ -130,7 +130,7 @@ VALID_INPUT_MSG = [
             "report": {
                 "reports": [],
             },
-            "RequestId": "ingress-service-7777777777-q4444/4444444444-000001",
+            "request_id": "ingress-service-7777777777-q4444/4444444444-000001",
         },
         id="adding optional elements",
     ),

--- a/test/publishers/idp_rule_processing_publisher_test.py
+++ b/test/publishers/idp_rule_processing_publisher_test.py
@@ -103,6 +103,7 @@ VALID_INPUT_MSG = [
             "metadata": {
                 "cluster_id": "uuid",
             },
+            "request_id": "ingress-service-7777777777-q4444/4444444444-000001",
         },
         {
             "path": "bucket/path/to/archive.tgz",
@@ -112,6 +113,7 @@ VALID_INPUT_MSG = [
             "report": {
                 "reports": [],
             },
+            "RequestId": "ingress-service-7777777777-q4444/4444444444-000001",
         },
         id="minimal valid",
     ),
@@ -120,6 +122,7 @@ VALID_INPUT_MSG = [
             "path": "bucket/path/to/archive.tgz",
             "original_path": "other_than_current_path",
             "metadata": {"cluster_id": "uuid", "external_organization": "an organization"},
+            "request_id": "ingress-service-7777777777-q4444/4444444444-000001",
         },
         {
             "path": "bucket/path/to/archive.tgz",
@@ -127,6 +130,7 @@ VALID_INPUT_MSG = [
             "report": {
                 "reports": [],
             },
+            "RequestId": "ingress-service-7777777777-q4444/4444444444-000001",
         },
         id="adding optional elements",
     ),


### PR DESCRIPTION
# Description

Adding request_id to output message of archive sync and rules processing to be able to use payload tracker

Fixes # (issue)

## Type of change

Please delete options that are not relevant.

- Bug fix (non-breaking change which fixes an issue)


## Testing steps
Tested in ephemeral on rules-processing and rules-uploader
## Checklist
* [ ] `pre-commit run -a` passes
* [ ] updated documentation wherever necessary
* [ ] added or modified tests if necessary
* [ ] updated schemas and validators in [insights-data-schemas](https://github.com/RedHatInsights/insights-data-schemas) in case of input/output change
