### PR TITLE
[CCXDEV-14678] fix(monitoring): don't use rate for inserted rows

### DIFF
--- a/dashboards/internal-data-pipeline.yaml
+++ b/dashboards/internal-data-pipeline.yaml
@@ -287,7 +287,7 @@ data:
               },
               "editorMode": "code",
               "exemplar": false,
-              "expr": "rate(inserted_rows{job=\"parquet-factory\", namespace=\"$parquet_factory_namespace\"}[5m])",
+              "expr": "inserted_rows{job=\"parquet-factory\", namespace=\"$parquet_factory_namespace\"}",
               "format": "time_series",
               "hide": false,
               "instant": false,


### PR DESCRIPTION
# Description

The `inserted_rows` metric shouldn't use a `rate`. I found it because if 2 consecutive runs aggregates the same amount of rows, it shows 0.

With rate:

<img width="1509" alt="image" src="https://github.com/user-attachments/assets/705102a3-531c-4940-9f53-3a70bdb4ece3" />

Without it:

<img width="1509" alt="image" src="https://github.com/user-attachments/assets/aa3d1db1-a09e-44ad-989e-43c9d2fe03c7" />


## Type of change

- Bug fix (non-breaking change which fixes an issue)

## Testing steps

UI

## Checklist
* [ ] `pre-commit run -a` passes
* [ ] updated documentation wherever necessary
* [ ] added or modified tests if necessary
* [ ] updated schemas and validators in [insights-data-schemas](https://github.com/RedHatInsights/insights-data-schemas) in case of input/output change
