### PR TITLE
Get the cluster_id from the identity structure when needed

### DIFF
--- a/ccx_messaging/consumers/decoded_ingress_consumer.py
+++ b/ccx_messaging/consumers/decoded_ingress_consumer.py
@@ -70,9 +70,12 @@ class DecodedIngressConsumer(KafkaConsumer):
         deserialized_msg = self.parse_decoded_ingress_message(value)
         LOG.debug("JSON message deserialized (%s): %s", self.log_pattern, deserialized_msg)
 
-        if "cluster_name" not in deserialized_msg or deserialized_msg["cluster_name"] is None:
+        if not deserialized_msg.get("cluster_name"):
             cluster_id = (
-                deserialized_msg.get("identity", {}).get("system", {}).get("cluster_id", None)
+                deserialized_msg.get("identity", {})
+                .get("identity", {})
+                .get("system", {})
+                .get("cluster_id", None)
             )
             deserialized_msg["cluster_name"] = cluster_id
 


### PR DESCRIPTION
# Description

When the cluster_id is missing from the deserialized message, we try first to locate it into the "identity" field. The wrong "path" to the final cluster_id was used due to a nested usage of "identity" field.

## Type of change

- Bug fix (non-breaking change which fixes an issue)

## Testing steps


## Checklist
* [x] `pre-commit run -a` passes
* [ ] updated documentation wherever necessary
* [ ] added or modified tests if necessary
* [ ] updated schemas and validators in [insights-data-schemas](https://github.com/RedHatInsights/insights-data-schemas) in case of input/output change
