### PR TITLE
Fix pytest running in CI

### DIFF
--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -6,7 +6,7 @@ on:
 
 jobs:
   pytest:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-latest
     strategy:
       matrix:
         python-version:


### PR DESCRIPTION
# Description

Apparently in #483 PR, the pytest jobs are being cancelled before started. My best guess is that the runner ubuntu-20.04 has been deprecated (tbh, it's the only difference between these job definitions and the rest)

## Type of change

- Bump-up dependent library (no changes in the code)

## Testing steps

To be tested in CI

## Checklist
* [ ] `pre-commit run -a` passes
* [ ] updated documentation wherever necessary
* [ ] added or modified tests if necessary
* [ ] updated schemas and validators in [insights-data-schemas](https://github.com/RedHatInsights/insights-data-schemas) in case of input/output change
