### PR TITLE
Add service_name for payload tracker

### DIFF
--- a/deploy/archive-sync-ols.yaml
+++ b/deploy/archive-sync-ols.yaml
@@ -168,6 +168,7 @@ objects:
             kwargs:
               bootstrap.servers: ${KAFKA_SERVER}
               topic: ${PAYLOAD_TRACKER_TOPIC}
+              service_name: archive-sync-ols
         logging:
           version: 1
           disable_existing_loggers: false

--- a/deploy/archive-sync.yaml
+++ b/deploy/archive-sync.yaml
@@ -170,6 +170,7 @@ objects:
             kwargs:
               bootstrap.servers: ${KAFKA_SERVER}
               topic: ${PAYLOAD_TRACKER_TOPIC}
+              service_name: archive-sync
         logging:
           version: 1
           disable_existing_loggers: false

--- a/deploy/multiplexor.yaml
+++ b/deploy/multiplexor.yaml
@@ -174,6 +174,7 @@ objects:
             kwargs:
               bootstrap.servers: ${KAFKA_SERVER}
               topic: ${PAYLOAD_TRACKER_TOPIC}
+              service_name: multiplexor
         logging:
           version: 1
           disable_existing_loggers: false

--- a/deploy/rules-uploader.yaml
+++ b/deploy/rules-uploader.yaml
@@ -165,6 +165,7 @@ objects:
             kwargs:
               bootstrap.servers: ${KAFKA_SERVER}
               topic: ${PAYLOAD_TRACKER_TOPIC}
+              service_name: rules-uploader
         logging:
           version: 1
           disable_existing_loggers: false


### PR DESCRIPTION
# Description

The ClowdApps config were missing the service_name for payload tracker and thus the status was not reported properly

## Type of change

- Bug fix (non-breaking change which fixes an issue)

## Testing steps


## Checklist
* [ ] `pre-commit run -a` passes
* [ ] updated documentation wherever necessary
* [ ] added or modified tests if necessary
* [ ] updated schemas and validators in [insights-data-schemas](https://github.com/RedHatInsights/insights-data-schemas) in case of input/output change
