### PR TITLE
Fix error handling in the publishers

### DIFF
--- a/ccx_messaging/publishers/idp_rule_processing_publisher.py
+++ b/ccx_messaging/publishers/idp_rule_processing_publisher.py
@@ -70,11 +70,3 @@ class IDPRuleProcessingPublisher(KafkaPublisher):
         # Convert message string into a byte array.
         self.produce(message.encode("utf-8"))
         log.debug("Message has been sent successfully.")
-
-    def error(self, input_msg: dict, ex: Exception):
-        """Handle pipeline errors by logging them."""
-        log.warning(
-            "An error has ocurred during the processing of %s: %s",
-            input_msg,
-            ex,
-        )

--- a/ccx_messaging/publishers/kafka_publisher.py
+++ b/ccx_messaging/publishers/kafka_publisher.py
@@ -86,11 +86,4 @@ class KafkaPublisher(Publisher):
 
     def error(self, input_msg: dict, ex: Exception):
         """Handle pipeline errors by logging them."""
-        # The super call is probably unnecessary because the default behavior
-        # is to do nothing, but let's call it in case it ever does anything.
-        super().error(input_msg, ex)
-
-        if not isinstance(ex, CCXMessagingError):
-            ex = CCXMessagingError(ex)
-
-        log.warning(ex.format(input_msg))
+        log.warning("An error has ocurred during the processing of %s: %s", input_msg, ex)

--- a/test/publishers/idp_rule_processing_publisher_test.py
+++ b/test/publishers/idp_rule_processing_publisher_test.py
@@ -179,6 +179,6 @@ def test_error(input, output):
 
     sut = IDPRuleProcessingPublisher("outgoing_topic", {"bootstrap.servers": "kafka:9092"})
 
-    with patch("ccx_messaging.publishers.idp_rule_processing_publisher.log") as log_mock:
+    with patch("ccx_messaging.publishers.kafka_publisher.log") as log_mock:
         sut.error(input, None)
         assert log_mock.warning.called


### PR DESCRIPTION
# Description

The handling of errors in `KafkaPublisher` is causing an unexpected error (nested exception) and an incorrect counting on failures for statistics purposes.

## Type of change

- Bug fix (non-breaking change which fixes an issue)
- Unit tests (no changes in the code)

## Testing steps

Tested locally (unit tests)

## Checklist
* [x] `pre-commit run -a` passes
* [ ] updated documentation wherever necessary
* [x] added or modified tests if necessary
* [ ] updated schemas and validators in [insights-data-schemas](https://github.com/RedHatInsights/insights-data-schemas) in case of input/output change
