### PR TITLE
Add parquet factory to the list of deployed service for testing

### DIFF
--- a/pr_check.sh
+++ b/pr_check.sh
@@ -22,7 +22,7 @@ set -exv
 APP_NAME="ccx-data-pipeline"  # name of app-sre "application" folder this component lives in
 COMPONENT_NAME="multiplexor archive-sync archive-sync-ols rules-uploader"  # name of app-sre "resourceTemplate" in deploy.yaml for this component
 IMAGE="quay.io/cloudservices/ccx-messaging"
-COMPONENTS="multiplexor archive-sync archive-sync-ols rules-processing rules-uploader"  # space-separated list of components to load
+COMPONENTS="multiplexor archive-sync archive-sync-ols rules-processing rules-uploader parquet-factory"  # space-separated list of components to load
 COMPONENTS_W_RESOURCES=""  # component to keep
 CACHE_FROM_LATEST_IMAGE="true"
 DEPLOY_FRONTENDS="false"


### PR DESCRIPTION
# Description

As the deployment of parquet-factory into ephemeral has been [fixed](https://gitlab.cee.redhat.com/ccx/parquet-factory/-/merge_requests/243) and we might have new [tests](https://issues.redhat.com/browse/CCXDEV-15150) for parquet factory, adding it to the list of services to be deployed for testing.

Related to [CCXDEV-15150](https://issues.redhat.com/browse/CCXDEV-15150)

## Type of change

## Testing steps

## Checklist
* [ ] `pre-commit run -a` passes
* [ ] updated documentation wherever necessary
* [ ] added or modified tests if necessary
* [ ] updated schemas and validators in [insights-data-schemas](https://github.com/RedHatInsights/insights-data-schemas) in case of input/output change
