### PR TITLE
[CCXDEV-15288] Updating Tar processing errors to be handled as one issue in Glitchtip

### DIFF
--- a/ccx_messaging/downloaders/http_downloader.py
+++ b/ccx_messaging/downloaders/http_downloader.py
@@ -15,13 +15,11 @@
 """Module that defines a Downloader object to get HTTP urls."""
 
 import logging
-import os
 import re
 from contextlib import contextmanager
 from tempfile import NamedTemporaryFile
 
 import requests
-from sentry_sdk import push_scope
 
 from ccx_messaging.error import CCXMessagingError
 
@@ -120,14 +118,5 @@ class HTTPDownloader:
             LOG.error("Connection error while downloading the file: %s", err)
             raise CCXMessagingError("Connection error while downloading the file") from err
         except Exception as err:
-            if "doesn't contain cluster id" in str(err):
-                with push_scope() as scope:
-                    scope.fingerprint = [
-                        "http_downloader",
-                        "Tar doesn't contain cluster id",
-                        os.getenv("SENTRY_ENVIRONMENT", "unknown"),
-                    ]
-                    LOG.error("Unknown error while downloading the file: %s", err)
-            else:
-                LOG.error("Unknown error while downloading the file: %s", err)
+            LOG.error("Unknown error while downloading the file: %s", err)
             raise CCXMessagingError("Unknown error while downloading the file") from err

--- a/ccx_messaging/engines/s3_upload_engine.py
+++ b/ccx_messaging/engines/s3_upload_engine.py
@@ -147,16 +147,14 @@ def extract_cluster_id(tar_path: str) -> str:
                 return id_file.read().decode()
 
     except KeyError as ex:
-        sentry_sdk.set_context("archive_processing", {
-            "tar_path": tar_path,
-            "error_type": "missing_cluster_id",
-            "id_path": ID_PATH
-        })
+        sentry_sdk.set_context(
+            "archive_processing",
+            {"tar_path": tar_path, "error_type": "missing_cluster_id", "id_path": ID_PATH},
+        )
         raise CCXMessagingError("Archive doesn't contain cluster id") from ex
 
     except tarfile.ReadError as ex:
-        sentry_sdk.set_context("archive_processing", {
-            "tar_path": tar_path,
-            "error_type": "invalid_tarfile"
-        })
+        sentry_sdk.set_context(
+            "archive_processing", {"tar_path": tar_path, "error_type": "invalid_tarfile"}
+        )
         raise CCXMessagingError("File doesn't look as a tarfile") from ex


### PR DESCRIPTION
# Description

Updating "Unknown error while downloading the file:%s" error log to be handled as  one issue in Glitchtip
Currently it is handled as multuple issues f.e. :

[Unknown error while downloading the file: The tar in /tmp/tmpb_9onanw doesn't contain cluster id](https://glitchtip.devshift.net/ccx/issues/3830328?project=109)

[Unknown error while downloading the file: The tar in /tmp/tmp_fnvnnod doesn't contain cluster id](https://glitchtip.devshift.net/ccx/issues/3830324?project=109)

Here is the issue that was created as i was testing new changes https://glitchtip.devshift.net/ccx/issues/3861309?project=109

Fixes # (issue)

## Type of change

Please delete options that are not relevant.

- Bug fix (non-breaking change which fixes an issue)
- Refactor (refactoring code, removing useless files)


## Checklist
* [ ] `pre-commit run -a` passes
* [ ] updated documentation wherever necessary
* [ ] added or modified tests if necessary
* [ ] updated schemas and validators in [insights-data-schemas](https://github.com/RedHatInsights/insights-data-schemas) in case of input/output change
