### PR TITLE
[CCXDEV-15296]Updating Multiplexor Glitchtip issues generation

### DIFF
--- a/ccx_messaging/downloaders/http_downloader.py
+++ b/ccx_messaging/downloaders/http_downloader.py
@@ -118,5 +118,18 @@ class HTTPDownloader:
             LOG.error("Connection error while downloading the file: %s", err)
             raise CCXMessagingError("Connection error while downloading the file") from err
         except Exception as err:
-            LOG.error("Unknown error while downloading the file: %s", err)
-            raise CCXMessagingError("Unknown error while downloading the file") from err
+            if "ReadError reading the archive" in str(err):
+                # Extract path from additional_data
+                additional_data = getattr(err, "additional_data", None)
+                path = additional_data.get("archive_path") if additional_data else None
+
+                LOG.error(
+                    "Unknown error while downloading the file: ReadError reading the archive",
+                    extra={"archive_path": path},
+                )
+                raise CCXMessagingError(
+                    "Unknown error while downloading the file: ReadError reading the archive"
+                ) from err
+            else:
+                LOG.error("Unknown error while downloading the file: %s", err)
+                raise CCXMessagingError("Unknown error while downloading the file") from err

--- a/ccx_messaging/downloaders/http_downloader.py
+++ b/ccx_messaging/downloaders/http_downloader.py
@@ -117,19 +117,17 @@ class HTTPDownloader:
         except requests.exceptions.ConnectionError as err:
             LOG.error("Connection error while downloading the file: %s", err)
             raise CCXMessagingError("Connection error while downloading the file") from err
-        except Exception as err:
-            if "ReadError reading the archive" in str(err):
-                # Extract path from additional_data
-                additional_data = getattr(err, "additional_data", None)
-                path = additional_data.get("archive_path") if additional_data else None
-
+        except CCXMessagingError as err:
+            additional_data = getattr(err, "additional_data", None)
+            if additional_data is not None:
                 LOG.error(
-                    "Unknown error while downloading the file: ReadError reading the archive",
-                    extra={"archive_path": path},
+                    "Unknown error while downloading the file: %s",
+                    err,
+                    extra=additional_data,
                 )
-                raise CCXMessagingError(
-                    "Unknown error while downloading the file: ReadError reading the archive"
-                ) from err
             else:
                 LOG.error("Unknown error while downloading the file: %s", err)
-                raise CCXMessagingError("Unknown error while downloading the file") from err
+            raise CCXMessagingError("Unknown error while downloading the file") from err
+        except Exception as err:
+            LOG.error("Unknown error while downloading the file: %s", err)
+            raise CCXMessagingError("Unknown error while downloading the file") from err

--- a/ccx_messaging/engines/multiplexor_engine.py
+++ b/ccx_messaging/engines/multiplexor_engine.py
@@ -73,7 +73,9 @@ class MultiplexorEngine(Engine):
                 marks.add("DEFAULT")
 
         except tarfile.ReadError as ex:
-            raise CCXMessagingError(f"ReadError reading the archive {path}") from ex
+            raise CCXMessagingError(
+                "ReadError reading the archive", additional_data={"archive_path": path}
+            ) from ex
 
         self.logger.info("Reporting marks: %s", marks)
         self.fire("on_engine_success", broker, marks)

--- a/ccx_messaging/error.py
+++ b/ccx_messaging/error.py
@@ -26,9 +26,9 @@ class CCXMessagingError(Exception):
         """Initialize CCXMessagingError with optional additional data.
 
         Args:
-        
             message: The error message
             additional_data: Optional dict containing additional context data
+
         """
         super().__init__(message)
         self.additional_data = additional_data

--- a/ccx_messaging/error.py
+++ b/ccx_messaging/error.py
@@ -29,8 +29,13 @@ class CCXMessagingError(Exception):
             message: The error message
             additional_data: Optional dict containing additional context data
 
+        Raises:
+            TypeError: If additional_data is not None or dict
+
         """
         super().__init__(message)
+        if additional_data is not None and not isinstance(additional_data, dict):
+            raise TypeError("additional_data must be a dict or None")
         self.additional_data = additional_data
 
     def format(self, input_msg):

--- a/ccx_messaging/error.py
+++ b/ccx_messaging/error.py
@@ -22,6 +22,17 @@ class CCXMessagingError(Exception):
     exceptions caused by internal and external code.
     """
 
+    def __init__(self, message, additional_data=None):
+        """Initialize CCXMessagingError with optional additional data.
+
+        Args:
+        
+            message: The error message
+            additional_data: Optional dict containing additional context data
+        """
+        super().__init__(message)
+        self.additional_data = additional_data
+
     def format(self, input_msg):
         """Format the error by adding information about input Kafka message."""
         return f"Status: Error; Topic: {input_msg['topic']}; Cause: {self}"

--- a/ccx_messaging/error.py
+++ b/ccx_messaging/error.py
@@ -22,18 +22,20 @@ class CCXMessagingError(Exception):
     exceptions caused by internal and external code.
     """
 
-    def __init__(self, message, additional_data=None):
+    def __init__(self, message, *args, additional_data=None):
         """Initialize CCXMessagingError with optional additional data.
 
         Args:
-            message: The error message
+            message: The error message (may contain format specifiers)
+            *args: Arguments for string formatting (for backward compatibility)
             additional_data: Optional dict containing additional context data
 
         Raises:
             TypeError: If additional_data is not None or dict
 
         """
-        super().__init__(message)
+        super().__init__(message, *args)
+
         if additional_data is not None and not isinstance(additional_data, dict):
             raise TypeError("additional_data must be a dict or None")
         self.additional_data = additional_data

--- a/test/error_test.py
+++ b/test/error_test.py
@@ -36,3 +36,33 @@ def test_error_formatting():
     fmt = err.format(input_msg)
     expected = "Status: Error; Topic: topic name; Cause: CCXMessagingError"
     assert fmt == expected
+
+
+def test_error_without_additional_data():
+    """Test CCXMessagingError without additional_data (backwards compatibility)."""
+    err = CCXMessagingError("Test error message")
+
+    assert err is not None
+    assert str(err) == "Test error message"
+    assert err.additional_data is None
+
+
+def test_error_with_additional_data():
+    """Test CCXMessagingError with additional_data parameter."""
+    test_data = {"archive_path": "/tmp/test.tar", "cluster_id": "test-cluster"}
+    err = CCXMessagingError("Test error with data", additional_data=test_data)
+
+    assert err is not None
+    assert str(err) == "Test error with data"
+    assert err.additional_data == test_data
+    assert err.additional_data["archive_path"] == "/tmp/test.tar"
+    assert err.additional_data["cluster_id"] == "test-cluster"
+
+
+def test_error_with_empty_additional_data():
+    """Test CCXMessagingError with empty dict as additional_data."""
+    err = CCXMessagingError("Test error", additional_data={})
+
+    assert err is not None
+    assert str(err) == "Test error"
+    assert err.additional_data == {}


### PR DESCRIPTION
# Description
Glitchtip was creating a separate issue for each tarfile.ReadError raised by the Multiplexor this one https://glitchtip.devshift.net/ccx/issues/3910784?project=104

CCXMessagingError was updated to include optional additional_data parameter which is used as a dict and does not break backwards compatibility

Adding unit tests for updated CCXMessagingError and also with help of CloudCode i have also created `test_multiplexor_engine_tarfile_error` test which checks if updated CCXMessagingError is behaving as expected when there is ReadError in multiplexor engine. 

Fixes # (issue)

## Type of change

Please delete options that are not relevant.
- Refactor (refactoring code, removing useless files)
- Unit tests (no changes in the code)

## Testing steps

Please describe how the change was tested locally. If, for some reason, the testing was not done or not done fully, please describe what are the testing steps.

## Checklist
* [ ] `pre-commit run -a` passes
* [ ] updated documentation wherever necessary
* [ ] added or modified tests if necessary
* [ ] updated schemas and validators in [insights-data-schemas](https://github.com/RedHatInsights/insights-data-schemas) in case of input/output change
