### PR TITLE
Reduce unit test runtime with Kafka Publisher - do not wait for librdkafka background threads

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -62,6 +62,11 @@ dev = [
     "ruff"
 ]
 
+[tool.pytest.ini_options]
+markers = [
+    "real_kafka_producer: test needs the real confluent_kafka.Producer (not mocked)",
+]
+
 [tool.setuptools_scm]
 
 [tool.ruff]

--- a/test/consumers/kafka_consumer_test.py
+++ b/test/consumers/kafka_consumer_test.py
@@ -247,7 +247,8 @@ def test_consumer_init_direct(topic, group, server):
         mock_consumer_init.assert_called_with(config)
 
 
-MAX_ELAPSED_TIME_BETWEEN_MESSAGES_TEST = 2
+# Must be > 1 because test_elapsed_time_thread_no_warning sleeps for (value - 1) seconds.
+MAX_ELAPSED_TIME_BETWEEN_MESSAGES_TEST = 1.1
 
 
 @patch("ccx_messaging.consumers.kafka_consumer.ConfluentConsumer", lambda *a, **k: MagicMock())

--- a/test/publishers/conftest.py
+++ b/test/publishers/conftest.py
@@ -1,0 +1,22 @@
+"""Shared fixtures for publisher tests."""
+
+from unittest.mock import MagicMock
+
+import pytest
+
+
+@pytest.fixture(autouse=True)
+def _mock_kafka_producer(request, monkeypatch):
+    """Prevent real confluent_kafka.Producer creation in publisher tests.
+
+    The real Producer spawns librdkafka background threads that block for ~4 seconds
+    on destruction when the broker is unreachable, causing the test suite to take
+    ~10 minutes instead of seconds.
+
+    Tests that need the real Producer (e.g. to verify config validation) can opt out
+    with @pytest.mark.real_kafka_producer.
+    """
+    if "real_kafka_producer" not in request.keywords:
+        monkeypatch.setattr(
+            "ccx_messaging.publishers.kafka_publisher.Producer", lambda *a, **kw: MagicMock()
+        )

--- a/test/publishers/dvo_metrics_publisher_test.py
+++ b/test/publishers/dvo_metrics_publisher_test.py
@@ -58,6 +58,7 @@ INVALID_KWARGS = [
 ]
 
 
+@pytest.mark.real_kafka_producer
 @pytest.mark.parametrize("kwargs", INVALID_KWARGS)
 def test_bad_initialization(kwargs):
     """Check that init fails when using not valid kwargs."""
@@ -65,6 +66,7 @@ def test_bad_initialization(kwargs):
         DVOMetricsPublisher(outgoing_topic="topic", **kwargs)
 
 
+@pytest.mark.real_kafka_producer
 @pytest.mark.parametrize("kafka_broker_cfg", INVALID_KWARGS)
 @pytest.mark.parametrize("kwargs", INVALID_KWARGS)
 def test_bad_init_with_kafka_config(kafka_broker_cfg, kwargs):

--- a/test/publishers/idp_rule_processing_publisher_test.py
+++ b/test/publishers/idp_rule_processing_publisher_test.py
@@ -57,6 +57,7 @@ INVALID_KWARGS = [
 ]
 
 
+@pytest.mark.real_kafka_producer
 @pytest.mark.parametrize("kwargs", INVALID_KWARGS)
 def test_bad_initialization(kwargs):
     """Check that init fails when using not valid kwargs."""
@@ -64,6 +65,7 @@ def test_bad_initialization(kwargs):
         IDPRuleProcessingPublisher(outgoing_topic="topic", **kwargs)
 
 
+@pytest.mark.real_kafka_producer
 @pytest.mark.parametrize("kafka_broker_cfg", INVALID_KWARGS)
 @pytest.mark.parametrize("kwargs", INVALID_KWARGS)
 def test_bad_init_with_kafka_config(kafka_broker_cfg, kwargs):

--- a/test/publishers/rule_processing_publisher_test.py
+++ b/test/publishers/rule_processing_publisher_test.py
@@ -58,6 +58,7 @@ INVALID_KWARGS = [
 ]
 
 
+@pytest.mark.real_kafka_producer
 @pytest.mark.parametrize("kwargs", INVALID_KWARGS)
 def test_bad_initialization(kwargs):
     """Check that init fails when using not valid kwargs."""
@@ -65,6 +66,7 @@ def test_bad_initialization(kwargs):
         RuleProcessingPublisher(outgoing_topic="topic", **kwargs)
 
 
+@pytest.mark.real_kafka_producer
 @pytest.mark.parametrize("kafka_broker_cfg", INVALID_KWARGS)
 @pytest.mark.parametrize("kwargs", INVALID_KWARGS)
 def test_bad_init_with_kafka_config(kafka_broker_cfg, kwargs):

--- a/test/publishers/workload_info_publisher_test.py
+++ b/test/publishers/workload_info_publisher_test.py
@@ -57,6 +57,7 @@ INVALID_KWARGS = [
 ]
 
 
+@pytest.mark.real_kafka_producer
 @pytest.mark.parametrize("kwargs", INVALID_KWARGS)
 def test_bad_initialization(kwargs):
     """Check that init fails when using not valid kwargs."""
@@ -64,6 +65,7 @@ def test_bad_initialization(kwargs):
         WorkloadInfoPublisher(outgoing_topic="topic", **kwargs)
 
 
+@pytest.mark.real_kafka_producer
 @pytest.mark.parametrize("kafka_broker_cfg", INVALID_KWARGS)
 @pytest.mark.parametrize("kwargs", INVALID_KWARGS)
 def test_bad_init_with_kafka_config(kafka_broker_cfg, kwargs):


### PR DESCRIPTION
# Description

Reduce unit test runtime with Kafka Publisher - do not wait for librdkafka background threads. This reduces the unit test runtime from 10 mins to ~30-40 sec.

## Type of change

- Integration tests (Kafka, Logstash etc.)