### PR TITLE
[CCXDEV-16243] Update Codecov integration to v5 with unit-tests flag

### DIFF
--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -22,7 +22,9 @@ jobs:
       - run: pip install tox-gh>=1.2
       - run: tox -vv
       - name: Upload coverage
-        uses: codecov/codecov-action@v4
+        uses: codecov/codecov-action@v5
         if: ${{ matrix.python-version == '3.11' }}
         with:
           token: ${{ secrets.CODECOV_TOKEN }}
+          flags: unit-tests
+          fail_ci_if_error: false


### PR DESCRIPTION
# Description

- Update `codecov/codecov-action` from v4 to v5
- Add `flags: unit-tests` for coverage categorization
- Add `fail_ci_if_error: false` to prevent CI failures if Codecov is unreachable

Fixes CCXDEV-16243

Cannot use shared WF because it uses tox and has a Python version matrix

## Type of change

- Configuration update