### PR TITLE
Fix python-version and update badges

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,8 +1,11 @@
 # insights-ccx-messaging
 
-[![GitHub Pages](https://img.shields.io/badge/%20-GitHub%20Pages-informational)](https://redhatinsights.github.io/insights-ccx-messaging/)
+[![PyPI version](https://img.shields.io/pypi/v/ccx-messaging)](https://pypi.org/project/ccx-messaging/)
+[![Python versions](https://img.shields.io/pypi/pyversions/ccx-messaging)]
+[![Python unit tests](https://github.com/RedHatInsights/insights-ccx-messaging/actions/workflows/pytests.yaml/badge.svg)](https://github.com/RedHatInsights/insights-ccx-messaging/actions/workflows/pytests.yaml)
 [![codecov](https://codecov.io/gh/RedHatInsights/insights-ccx-messaging/branch/main/graph/badge.svg?token=G00EQ808EP)](https://codecov.io/gh/RedHatInsights/insights-ccx-messaging)
 [![License](https://img.shields.io/badge/license-Apache-blue)](https://github.com/RedHatInsights/insights-ccx-messaging/blob/main/LICENSE)
+[![GitHub Pages](https://img.shields.io/badge/%20-GitHub%20Pages-informational)](https://redhatinsights.github.io/insights-ccx-messaging/)
 
 Stub for all CCX services based on Insights Core Messaging framework
 

--- a/ccx_messaging/publishers/dvo_metrics_publisher.py
+++ b/ccx_messaging/publishers/dvo_metrics_publisher.py
@@ -16,7 +16,6 @@
 
 import json
 import logging
-from typing import Dict
 
 from ccx_messaging.error import CCXMessagingError
 from ccx_messaging.publishers.kafka_publisher import KafkaPublisher
@@ -27,7 +26,7 @@ log = logging.getLogger(__name__)
 class DVOMetricsPublisher(KafkaPublisher):
     """DVOMetricsPublisher handles the result of the extraction of DVO metrics from an archive."""
 
-    def publish(self, input_msg: Dict, report: str) -> None:
+    def publish(self, input_msg: dict, report: str) -> None:
         """Publish an EOL-terminated JSON message to the output Kafka topic.
 
         The response is assumed to be a string representing a valid JSON object.

--- a/ccx_messaging/publishers/synced_archive_publisher.py
+++ b/ccx_messaging/publishers/synced_archive_publisher.py
@@ -16,7 +16,6 @@
 
 import json
 import logging
-from typing import Dict
 
 from ccx_messaging.publishers.kafka_publisher import KafkaPublisher
 
@@ -26,7 +25,7 @@ LOG = logging.getLogger(__name__)
 class SyncedArchivePublisher(KafkaPublisher):
     """Publisher for interanal data pipeline."""  # noqa: D203
 
-    def publish(self, input_msg: Dict, report: str) -> None:
+    def publish(self, input_msg: dict, report: str) -> None:
         """Publish response as Kafka message to outgoing topic."""
         output_msg = json.loads(report)
         output_msg.pop("reports", None)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -22,7 +22,7 @@ classifiers = [
     "Programming Language :: Python :: 3.12"
 ]
 
-requires-python = ">= 3.8"
+requires-python = ">= 3.11"
 dependencies = [
     "app-common-python>=0.2.3",
     "boto3>=1.42.91,<1.42.92",  # limited due to incompatibility between aiobotocore and newer versions of boto

--- a/test/consumers/idp_kafka_consumer_test.py
+++ b/test/consumers/idp_kafka_consumer_test.py
@@ -282,8 +282,8 @@ def test_last_received_message_time_is_updated():
 
     [CCXDEV-14812] the variable is never updated
     """
-    t1 = datetime.datetime(2025, 1, 31, 12, 0, 0, tzinfo=datetime.timezone.utc)
-    t2 = datetime.datetime(2025, 1, 31, 12, 20, 0, tzinfo=datetime.timezone.utc)
+    t1 = datetime.datetime(2025, 1, 31, 12, 0, 0, tzinfo=datetime.UTC)
+    t2 = datetime.datetime(2025, 1, 31, 12, 20, 0, tzinfo=datetime.UTC)
 
     with freeze_time(t1) as frozen_time:
         sut = IDPConsumer(None, None, None, incoming_topic=None)

--- a/test/consumers/kafka_consumer_test.py
+++ b/test/consumers/kafka_consumer_test.py
@@ -232,9 +232,10 @@ _VALID_SERVERS = ["server", "great.server.net"]
 @pytest.mark.parametrize("server", _VALID_SERVERS)
 def test_consumer_init_direct(topic, group, server):
     """Test of our Consumer constructor, using direct configuration options."""
-    with patch(
-        "ccx_messaging.consumers.kafka_consumer.ConfluentConsumer"
-    ) as mock_consumer_init, patch("os.environ", new={}):
+    with (
+        patch("ccx_messaging.consumers.kafka_consumer.ConfluentConsumer") as mock_consumer_init,
+        patch("os.environ", new={}),
+    ):
         kwargs = {
             "group.id": group,
             "bootstrap.servers": server,
@@ -396,11 +397,12 @@ def test_non_processed_to_dlq(value, expected):
     sut = KafkaConsumer(None, None, None, None)
     input_msg = KafkaMessage(value)
 
-    with patch(
-        "ccx_messaging.consumers.kafka_consumer.KafkaConsumer.process"
-    ) as process_mock, patch(
-        "ccx_messaging.consumers.kafka_consumer.KafkaConsumer.process_dead_letter"
-    ) as process_dlq_mock:
+    with (
+        patch("ccx_messaging.consumers.kafka_consumer.KafkaConsumer.process") as process_mock,
+        patch(
+            "ccx_messaging.consumers.kafka_consumer.KafkaConsumer.process_dead_letter"
+        ) as process_dlq_mock,
+    ):
         process_mock.side_effect = [CCXMessagingError, TimeoutError, IndexError]
         sut.process_msg(input_msg)
         process_dlq_mock.assert_called_with(input_msg)
@@ -522,8 +524,8 @@ def test_last_received_message_time_is_updated():
 
     [CCXDEV-14812] the variable is never updated
     """
-    t1 = datetime.datetime(2025, 1, 31, 12, 0, 0, tzinfo=datetime.timezone.utc)
-    t2 = datetime.datetime(2025, 1, 31, 12, 20, 0, tzinfo=datetime.timezone.utc)
+    t1 = datetime.datetime(2025, 1, 31, 12, 0, 0, tzinfo=datetime.UTC)
+    t2 = datetime.datetime(2025, 1, 31, 12, 20, 0, tzinfo=datetime.UTC)
 
     with freeze_time(t1) as frozen_time:
         sut = KafkaConsumer(None, None, None, None)

--- a/test/consumers/synced_archive_consumer_test.py
+++ b/test/consumers/synced_archive_consumer_test.py
@@ -235,8 +235,8 @@ def test_last_received_message_time_is_updated():
 
     [CCXDEV-14812] the variable is never updated
     """
-    t1 = datetime.datetime(2025, 1, 31, 12, 0, 0, tzinfo=datetime.timezone.utc)
-    t2 = datetime.datetime(2025, 1, 31, 12, 20, 0, tzinfo=datetime.timezone.utc)
+    t1 = datetime.datetime(2025, 1, 31, 12, 0, 0, tzinfo=datetime.UTC)
+    t2 = datetime.datetime(2025, 1, 31, 12, 20, 0, tzinfo=datetime.UTC)
 
     with freeze_time(t1) as frozen_time:
         sut = SyncedArchiveConsumer(None, None, None, None)

--- a/test/engines/s3_uploader_engine_test.py
+++ b/test/engines/s3_uploader_engine_test.py
@@ -288,8 +288,9 @@ def test_extract_cluster_id_from_non_tarfile():
 def test_extract_cluster_id_missing_config_id():
     """Test that extract_cluster_id raises error when tar doesn't have config/id."""
     # Use an archive without config/id (wrong_data archive doesn't have it)
-    with tarfile.open("test/wrong_data.tar") as tf, pytest.raises(
-        CCXMessagingError, match="doesn't contain cluster id"
+    with (
+        tarfile.open("test/wrong_data.tar") as tf,
+        pytest.raises(CCXMessagingError, match="doesn't contain cluster id"),
     ):
         extract_cluster_id(tf, "test/wrong_data.tar")
 


### PR DESCRIPTION
# Description

Set the Python required version to 3.11, we are not testing anything with lower versions

## Type of change

- Documentation update

## Testing steps

N/A

## Checklist
* [ ] `pre-commit run -a` passes
* [ ] updated documentation wherever necessary
* [ ] added or modified tests if necessary
* [ ] updated schemas and validators in [insights-data-schemas](https://github.com/RedHatInsights/insights-data-schemas) in case of input/output change
