### PR TITLE
[CCXDEV-16445] Fix botocore conflicts - use 1.43.1

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -15,8 +15,6 @@ classifiers = [
     "License :: OSI Approved :: Apache Software License",
     "Programming Language :: Python",
     "Programming Language :: Python :: 3",
-    "Programming Language :: Python :: 3.8",
-    "Programming Language :: Python :: 3.9",
     "Programming Language :: Python :: 3.10",
     "Programming Language :: Python :: 3.11",
     "Programming Language :: Python :: 3.12"
@@ -25,7 +23,7 @@ classifiers = [
 requires-python = ">= 3.11"
 dependencies = [
     "app-common-python>=0.2.3",
-    "boto3>=1.43.29,<1.43.30",  # limited due to incompatibility between aiobotocore and newer versions of boto
+    "boto3>=1.42.90,<1.43.1",  # limited due to incompatibility between aiobotocore and newer versions of boto
     "confluent-kafka>=2.0.0",
     "insights-core>=3.1.2",
     "insights-core-messaging @ git+https://github.com/RedHatInsights/insights-core-messaging@1.2.21",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -25,7 +25,7 @@ classifiers = [
 requires-python = ">= 3.11"
 dependencies = [
     "app-common-python>=0.2.3",
-    "boto3>=1.42.91,<1.42.92",  # limited due to incompatibility between aiobotocore and newer versions of boto
+    "boto3>=1.43.29,<1.43.30",  # limited due to incompatibility between aiobotocore and newer versions of boto
     "confluent-kafka>=2.0.0",
     "insights-core>=3.1.2",
     "insights-core-messaging @ git+https://github.com/RedHatInsights/insights-core-messaging@1.2.21",

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,5 @@
 app-common-python>=0.2.3
-boto3>=1.42.91,<1.42.92
+boto3>=1.43.29,<1.43.30
 confluent-kafka>=2.0.0
 insights-core>=3.1.2
 insights-core-messaging @ git+https://github.com/RedHatInsights/insights-core-messaging@1.2.21
@@ -11,5 +11,5 @@ requests>=2.31.0
 sentry-sdk>=1.37.1
 watchtower>=3.0.0
 setuptools>=70.0.0
-aiobotocore==3.5.0
-s3fs==2026.3.0
+aiobotocore==3.7.0
+s3fs==2026.4.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,5 @@
 app-common-python>=0.2.3
-boto3>=1.43.29,<1.43.30
+boto3>=1.42.90,<1.43.1
 confluent-kafka>=2.0.0
 insights-core>=3.1.2
 insights-core-messaging @ git+https://github.com/RedHatInsights/insights-core-messaging@1.2.21

--- a/test-requirements.txt
+++ b/test-requirements.txt
@@ -1,3 +1,3 @@
 freezegun==1.5.5
-pytest==9.0.3
+pytest==9.1.0
 pytest-cov==7.1.0


### PR DESCRIPTION
# Description

[CCXDEV-16445] Fix botocore conflicts - use 1.43.1
Replaces failing mintmaker PR: https://github.com/RedHatInsights/insights-ccx-messaging/pull/753

## Type of change

- Bump-up dependent library (no changes in the code)


[CCXDEV-16445]: https://redhat.atlassian.net/browse/CCXDEV-16445?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ